### PR TITLE
starsim refactoring

### DIFF
--- a/stisim/__init__.py
+++ b/stisim/__init__.py
@@ -6,6 +6,7 @@ from .distributions import *
 from .states        import *
 from .people        import *
 from .modules       import *
+from .disease       import *
 from .networks      import *
 from .results       import *
 from .demographics  import *

--- a/stisim/analyzers.py
+++ b/stisim/analyzers.py
@@ -10,6 +10,9 @@ __all__ = ['Analyzer']
 
 class Analyzer(ss.Module):
 
+    def __call__(self, *args, **kwargs):
+        return self.apply(*args, **kwargs)
+
     def update_results(self, sim):
         raise NotImplementedError
 

--- a/stisim/demographics.py
+++ b/stisim/demographics.py
@@ -14,9 +14,19 @@ class DemographicModule(ss.Module):
     # A demographic module typically handles births/deaths/migration and takes
     # place at the start of the timestep, before networks are updated and before
     # any disease modules are executed
-    pass
-    # TODO - add common demographic-related functionality here
 
+    def initialize(self, sim):
+        super().initialize(sim)
+        self.init_results(sim)
+        return
+
+    def init_results(self, sim):
+        pass
+
+    def update(self, sim):
+        # Note that for demographic modules, any result updates should be
+        # carried out inside this function
+        pass
 
 class births(DemographicModule):
     def __init__(self, pars=None):
@@ -50,10 +60,6 @@ class births(DemographicModule):
         self.pars.birth_rates = birth_rates
         return
 
-    def initialize(self, sim):
-        super().initialize(sim)
-        self.init_results(sim)
-        return
 
     def init_results(self, sim):
         self.results += ss.Result(self.name, 'new', sim.npts, dtype=int)
@@ -88,6 +94,7 @@ class births(DemographicModule):
         self.results['new'][sim.ti] = n_new
 
     def finalize(self, sim):
+        super().finalize(sim)
         self.results['cumulative'] = np.cumsum(self.results['new'])
         self.results['cbr'] = self.results['new'] / sim.results['pop_size']
 
@@ -160,11 +167,6 @@ class background_deaths(DemographicModule):
 
         self.pars.death_rates = df
 
-        return
-
-    def initialize(self, sim):
-        super().initialize(sim)
-        self.init_results(sim)
         return
 
     def init_results(self, sim):
@@ -244,7 +246,6 @@ class Pregnancy(DemographicModule):
 
     def initialize(self, sim):
         super().initialize(sim)
-        self.init_results(sim)
         sim.pars['birth_rates'] = None  # This turns off birth rate pars so births only come from this module
         return
 

--- a/stisim/disease.py
+++ b/stisim/disease.py
@@ -1,0 +1,182 @@
+import numpy as np
+import sciris as sc
+import stisim as ss
+
+__all__ = ['Disease', 'STI']
+
+class Disease(ss.Module):
+    """ Base module contains states/attributes that all modules have """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.results = ss.ndict(type=ss.Result)
+
+    def initialize(self, sim):
+        super().initialize(sim)
+        self.validate_pars(sim)
+        self.set_initial_states(sim)
+        self.init_results(sim)
+        return
+
+    def finalize(self, sim):
+        super().finalize(sim)
+        self.finalize_results(sim)
+
+    def validate_pars(self, sim):
+        """
+        Perform any parameter validation
+
+        :return: None if parameters are all valid
+        :raises: Exception if there are any invalid parameters (or if the initialization is otherwise invalid in some way)
+        """
+        pass
+
+    def set_initial_states(self, sim):
+        """
+        Set initial values for states
+
+        This could involve passing in a full set of initial conditions,
+        or using init_prev, or other. Note that this is different to initialization of the State objects
+        i.e., creating their dynamic array, linking them to a People instance. That should have already
+        taken place by the time this method is called. This method is about supplying initial values
+        for the states (e.g., seeding initial infections)
+        """
+        pass
+
+    def init_results(self, sim):
+        """
+        Initialize results
+        """
+        pass
+
+    def finalize_results(self, sim):
+        """
+        Finalize results
+        """
+        pass
+
+    def update_pre(self, sim):
+        """
+        Carry out autonomous updates at the start of the timestep (prior to transmission)
+
+        :param sim:
+        :return:
+        """
+        pass
+
+    def make_new_cases(self, sim):
+        """
+        Add new cases of the disease
+
+        This method is agnostic as to the mechanism by which new cases occur. This
+        could be through transmission (parametrized in different ways, which may or
+        may not use the contact networks) or it may be based on risk factors/seeding,
+        as may be the case for non-communicable diseases.
+        """
+        pass
+
+    def set_prognoses(self, sim, uids):
+        pass
+
+    def update_results(self, sim):
+        """
+        Update results
+
+        This function is executed after transmission in all modules has been resolved.
+        This allows result updates at this point to capture outcomes dependent on multiple
+        modules, where relevant.
+        """
+        pass
+
+
+
+class STI(Disease):
+    """ Base module contains states/attributes that all modules have """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.rel_sus = ss.State('rel_sus', float, 1)
+        self.rel_sev = ss.State('rel_sev', float, 1)
+        self.rel_trans = ss.State('rel_trans', float, 1)
+        self.susceptible = ss.State('susceptible', bool, True)
+        self.infected = ss.State('infected', bool, False)
+        self.ti_infected = ss.State('ti_infected', int, ss.INT_NAN)
+        return
+
+    def initialize(self, sim):
+        super().initialize(sim)
+
+        # Initialization steps
+        self.validate_pars(sim)
+        self.set_initial_states(sim)
+        self.init_results(sim)
+        return
+
+    def validate_pars(self, sim):
+        """
+        Perform any parameter validation
+        """
+        if 'beta' not in self.pars:
+            self.pars.beta = sc.objdict({k: [1, 1] for k in sim.people.networks})
+        return
+
+    def set_initial_states(self, sim):
+        """
+        Set initial values for states. This could involve passing in a full set of initial conditions,
+        or using init_prev, or other. Note that this is different to initialization of the State objects
+        i.e., creating their dynamic array, linking them to a People instance. That should have already
+        taken place by the time this method is called.
+        """
+        n_init_cases = int(self.pars['init_prev'] * len(sim.people))
+        initial_cases = np.random.choice(sim.people.uid, n_init_cases, replace=False)
+        self.set_prognoses(sim, initial_cases)
+        return
+
+    def init_results(self, sim):
+        """
+        Initialize results
+        """
+        self.results += ss.Result(self.name, 'n_susceptible', sim.npts, dtype=int)
+        self.results += ss.Result(self.name, 'n_infected', sim.npts, dtype=int)
+        self.results += ss.Result(self.name, 'prevalence', sim.npts, dtype=float)
+        self.results += ss.Result(self.name, 'new_infections', sim.npts, dtype=int)
+        return
+
+    def update_pre(self, sim):
+        """
+        Carry out autonomous updates at the start of the timestep (prior to transmission)
+
+        :param sim:
+        :return:
+        """
+        pass
+
+    def make_new_cases(self, sim):
+        """ Add new cases of module, through transmission, incidence, etc. """
+        pars = self.pars
+        for k, layer in sim.people.networks.items():
+            if k in pars['beta']:
+                contacts = layer.contacts
+                rel_trans = (self.infected & sim.people.alive).astype(float) * self.rel_trans
+                rel_sus = (self.susceptible & sim.people.alive).astype(float) * self.rel_sus
+                for a, b, beta in [[contacts.p1, contacts.p2, pars.beta[k][0]],
+                                   [contacts.p2, contacts.p1, pars.beta[k][1]]]:
+                    # probability of a->b transmission
+                    p_transmit = rel_trans[a] * rel_sus[b] * contacts.beta * beta
+                    new_cases = np.random.random(len(a)) < p_transmit
+                    if np.any(new_cases):
+                        self.set_prognoses(sim, b[new_cases])
+
+    def set_prognoses(self, sim, uids):
+        pass
+
+    def set_congenital(self, sim, uids):
+        # Need to figure out whether we would have a methods like this here or make it
+        # part of a pregnancy/STI connector
+        pass
+
+    def update_results(self, sim):
+        self.results['n_susceptible'][sim.ti] = np.count_nonzero(self.susceptible)
+        self.results['n_infected'][sim.ti] = np.count_nonzero(self.infected)
+        self.results['prevalence'][sim.ti] = self.results.n_infected[sim.ti] / np.count_nonzero(sim.people.alive)
+        self.results['new_infections'][sim.ti] = np.count_nonzero(self.ti_infected == sim.ti)

--- a/stisim/distributions.py
+++ b/stisim/distributions.py
@@ -43,7 +43,7 @@ class Distribution():
     def name(self):
         return self.__class__.__name__
 
-    def sample(cls, n=1, **kwargs):
+    def sample(self, n=1, **kwargs):
         """
         Return a specified number of samples from the distribution
         """
@@ -65,6 +65,16 @@ class Distribution():
         else:
             raise KeyError(f'Distribution "{name}" did not match any known distributions')
 
+class delta(Distribution):
+    """
+    Delta function at specified value
+    """
+
+    def __init__(self, value):
+        self.value = value
+
+    def sample(self, n=1):
+        return np.full(n, fill_value=self.value)
 
 class data_dist(Distribution):
     """ Sample from data """

--- a/stisim/gonorrhea.py
+++ b/stisim/gonorrhea.py
@@ -9,7 +9,7 @@ import stisim as ss
 __all__ = ['Gonorrhea']
 
 
-class Gonorrhea(ss.Disease):
+class Gonorrhea(ss.STI):
 
     def __init__(self, pars=None):
         super().__init__(pars)
@@ -37,7 +37,7 @@ class Gonorrhea(ss.Disease):
         Initialize results
         """
         super().init_results(sim)
-        self.results += ss.Result(self.name, 'n_sympotmatic', sim.npts, dtype=int)
+        self.results += ss.Result(self.name, 'n_symptomatic', sim.npts, dtype=int)
         self.results += ss.Result(self.name, 'new_clearances', sim.npts, dtype=int)
         return
 

--- a/stisim/hiv.py
+++ b/stisim/hiv.py
@@ -9,7 +9,7 @@ import stisim as ss
 __all__ = ['HIV', 'ART', 'CD4_analyzer']
 
 
-class HIV(ss.Disease):
+class HIV(ss.STI):
 
     def __init__(self, pars=None):
         super().__init__(pars)

--- a/stisim/interventions.py
+++ b/stisim/interventions.py
@@ -10,5 +10,9 @@ __all__ = ['Intervention']
 
 class Intervention(ss.Module):
 
-    def apply(self):
+
+    def __call__(self, *args, **kwargs):
+        return self.apply(*args, **kwargs)
+
+    def apply(self, sim, *args, **kwargs):
         raise NotImplementedError

--- a/stisim/modules.py
+++ b/stisim/modules.py
@@ -6,13 +6,14 @@ import numpy as np
 import sciris as sc
 import stisim as ss
 
-__all__ = ['Module', 'Disease']
+__all__ = ['Module']
 
 
 class Module(sc.prettyobj):
 
-    def __init__(self, pars=None, label=None, requires=None, *args, **kwargs):
+    def __init__(self, pars=None, name = None, label=None, requires=None, *args, **kwargs):
         self.pars = ss.omerge(pars)
+        self.name = name if name else self.__class__.__name__.lower() # Default name is the class name
         self.label = label if label else ''
         self.requires = sc.mergelists(requires)
         self.results = ss.ndict(type=ss.Result)
@@ -20,20 +21,21 @@ class Module(sc.prettyobj):
         self.finalized = False
         return
 
-    def __call__(self, *args, **kwargs):
-        """ Makes module(sim) equivalent to module.apply(sim) """
-        if not self.initialized:  # pragma: no cover
-            errormsg = f'{self.name} (label={self.label}) has not been initialized'
-            raise RuntimeError(errormsg)
-        return self.apply(*args, **kwargs)
-
     def check_requires(self, sim):
         for req in self.requires:
             if req not in sim.modules:
-                raise Exception(f'{self.__name__} requires module {req} but the Sim did not contain this module')
+                raise Exception(f'{self.name} (label={self.label}) requires module {req} but the Sim did not contain this module')
         return
 
     def initialize(self, sim):
+        """
+        Perform initialization steps
+
+        This method is called once, as part of initializing a Sim
+
+        :param sim:
+        :return:
+        """
         self.check_requires(sim)
 
         # Connect the states to the sim
@@ -46,11 +48,6 @@ class Module(sc.prettyobj):
     def finalize(self, sim):
         self.finalized = True
         return
-
-    @property
-    def name(self):
-        """ The module name is a lower-case version of its class name """
-        return self.__class__.__name__.lower()
 
     @property
     def states(self):
@@ -67,97 +64,3 @@ class Module(sc.prettyobj):
         """
         return [x for x in self.__dict__.values() if isinstance(x, ss.State)]
 
-
-class Disease(Module):
-    """ Base module contains states/attributes that all modules have """
-
-    def __init__(self, pars=None, *args, **kwargs):
-        super().__init__(pars, *args, **kwargs)
-        self.rel_sus = ss.State('rel_sus', float, 1)
-        self.rel_sev = ss.State('rel_sev', float, 1)
-        self.rel_trans = ss.State('rel_trans', float, 1)
-        self.susceptible = ss.State('susceptible', bool, True)
-        self.infected = ss.State('infected', bool, False)
-        self.ti_infected = ss.State('ti_infected', int, ss.INT_NAN)
-        return
-
-    def initialize(self, sim):
-        super().initialize(sim)
-
-        # Initialization steps
-        self.validate_pars(sim)
-        self.set_initial_states(sim)
-        self.init_results(sim)
-        return
-
-    def validate_pars(self, sim):
-        """
-        Perform any parameter validation
-        """
-        if 'beta' not in self.pars:
-            self.pars.beta = sc.objdict({k: [1, 1] for k in sim.people.networks})
-        return
-
-    def set_initial_states(self, sim):
-        """
-        Set initial values for states. This could involve passing in a full set of initial conditions,
-        or using init_prev, or other. Note that this is different to initialization of the State objects
-        i.e., creating their dynamic array, linking them to a People instance. That should have already
-        taken place by the time this method is called.
-        """
-        n_init_cases = int(self.pars['init_prev'] * len(sim.people))
-        initial_cases = np.random.choice(sim.people.uid, n_init_cases, replace=False)
-        self.set_prognoses(sim, initial_cases)
-        return
-
-    def init_results(self, sim):
-        """
-        Initialize results
-        """
-        self.results += ss.Result(self.name, 'n_susceptible', sim.npts, dtype=int)
-        self.results += ss.Result(self.name, 'n_infected', sim.npts, dtype=int)
-        self.results += ss.Result(self.name, 'prevalence', sim.npts, dtype=float)
-        self.results += ss.Result(self.name, 'new_infections', sim.npts, dtype=int)
-        return
-
-    def update_pre(self, sim):
-        """
-        Carry out autonomous updates at the start of the timestep (prior to transmission)
-
-        :param sim:
-        :return:
-        """
-        pass
-
-    def make_new_cases(self, sim):
-        """ Add new cases of module, through transmission, incidence, etc. """
-        pars = self.pars
-        for k, layer in sim.people.networks.items():
-            if k in pars['beta']:
-                contacts = layer.contacts
-                rel_trans = (self.infected & sim.people.alive).astype(float) * self.rel_trans
-                rel_sus = (self.susceptible & sim.people.alive).astype(float) * self.rel_sus
-                for a, b, beta in [[contacts.p1, contacts.p2, pars.beta[k][0]],
-                                   [contacts.p2, contacts.p1, pars.beta[k][1]]]:
-                    # probability of a->b transmission
-                    p_transmit = rel_trans[a] * rel_sus[b] * contacts.beta * beta
-                    new_cases = np.random.random(len(a)) < p_transmit
-                    if np.any(new_cases):
-                        self.set_prognoses(sim, b[new_cases])
-
-    def set_prognoses(self, sim, uids):
-        pass
-
-    def set_congenital(self, sim, uids):
-        # Need to figure out whether we would have a methods like this here or make it
-        # part of a pregnancy/STI connector
-        pass
-
-    def update_results(self, sim):
-        self.results['n_susceptible'][sim.ti] = np.count_nonzero(self.susceptible)
-        self.results['n_infected'][sim.ti] = np.count_nonzero(self.infected)
-        self.results['prevalence'][sim.ti] = self.results.n_infected[sim.ti] / np.count_nonzero(sim.people.alive)
-        self.results['new_infections'][sim.ti] = np.count_nonzero(self.ti_infected == sim.ti)
-
-    def finalize_results(self, sim):
-        pass

--- a/stisim/networks.py
+++ b/stisim/networks.py
@@ -81,9 +81,6 @@ class Network(ss.Module):
         self.debut = ss.State('debut', float, fill_value=0)
         return
 
-    @property
-    def name(self):
-        return self.__class__.__name__.lower()
 
     def initialize(self, sim):
         super().initialize(sim)

--- a/stisim/sim.py
+++ b/stisim/sim.py
@@ -6,7 +6,7 @@ Define core Sim classes
 import numpy as np
 import sciris as sc
 import stisim as ss
-
+import itertools
 
 __all__ = ['Sim', 'AlreadyRunError']
 
@@ -52,6 +52,18 @@ class Sim(sc.prettyobj):
     @property
     def year(self):
         return self.yearvec[self.ti]
+
+    @property
+    def modules(self):
+        # Return iterator over all Module instances (stored in standard places) in the Sim
+        return itertools.chain(
+            self.demographics.values(),
+            self.people.networks.values(),
+            self.diseases.values(),
+            self.connectors.values(),
+            self.interventions.values(),
+            self.analyzers.values(),
+        )
 
     def initialize(self, popdict=None, reset=False, **kwargs):
         """
@@ -433,7 +445,9 @@ class Sim(sc.prettyobj):
             # otherwise the scale factor will be applied multiple times
             raise AlreadyRunError('Simulation has already been finalized')
 
-        # Final settings
+        for module in self.modules:
+            module.finalize(self)
+
         self.results_ready = True  # Set this first so self.summary() knows to print the results
         self.ti -= 1  # During the run, this keeps track of the next step; restore this be the final day of the sim
         return


### PR DESCRIPTION
This PR has a few updates to make some of the classes a bit more generic and more reusable for starsim. The main changes are

- The `Disease` class is now more generic to cater to non-STIs, by not assuming there's an `infected` state or implementing transmission (these also wouldn't be relevant to NCDs). To cater to infectious diseases for STIsim, a new class `STI` is present containing the code previously in `Disease` and which STIsim-specific disease modules like HIV and gonorrhea can inherit from. This would still facilitate implementing STIsim connectors, they would bee developed against the STI class now rather than Disease
- Module names can now be specified explicitly although they default to the class name. The class name default kind of made sense for disease modules but felt a bit too limiting for networks (at least in the Gavi model context)
- Updated `sim.py` to call the `finalize` method for all modules at the end of the simulation