### PR TITLE
Add in syphilis-related adverse birth outcomes

### DIFF
--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -83,9 +83,6 @@ class Syphilis(STI):
         )
         self.pars = ss.omerge(default_pars, self.pars)
 
-        # Extra conception probability
-        self.conception_dist = sps.bernoulli(p=0)
-
         return
 
     @property

--- a/tests/test_syphilis.py
+++ b/tests/test_syphilis.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 import scipy.stats as sps
 
 
-def make_syph_sim(birth_outcomes=None):
+def make_syph_sim():
     """ Make a sim with syphilis - used by several subsequent tests """
     syph = ss.Syphilis()
     syph.pars['beta'] = {'mf': [0.95, 0.75], 'maternal': [0.99, 0]}


### PR DESCRIPTION
Originally I had planned for this branch to include a mechanism for adjusting the number of pregnancies to account for those lost to syphilis-related complications. However, after experimenting with a few options I think we should _not_ do this by default. Preferable options might include:
1. Defining a connector between the pregnancy and syphilis modules, and using this to adjust fertility rates
2. Generating pregnancies using parameters on conception probability and pregnancy loss probabilities, which the user would then need to calibrate to match births. 
