### PR TITLE
#31 P1/P2 sex order

### DIFF
--- a/starsim/networks/networks.py
+++ b/starsim/networks/networks.py
@@ -784,9 +784,9 @@ class hpv_network(mf):
             selected_males = m[np.array(choices).flatten()]
             f = f[f_paired_bools]
 
-        p1 = f
-        p2 = selected_males
-        n_partnerships = len(p1)
+        p1 = selected_males
+        p2 = f
+        n_partnerships = len(p2)
         dur = self.pars.duration_dist.rvs(n_partnerships)
         acts = self.pars.act_dist.rvs(n_partnerships)
         age_p1 = people.age[p1]


### PR DESCRIPTION
I only found one instance of p1/p2 being not m/f when using m/f pairing. There are no uses in main branch of the hpv_network outside of the test so this change should not have any direct side effects. Will resolve #31 when merged.