### PR TITLE
Fixes/duplicate validate names

### DIFF
--- a/starsim/diseases/disease.py
+++ b/starsim/diseases/disease.py
@@ -99,7 +99,8 @@ class Disease(ss.Module):
         super().__init__(*args, **kwargs)
         self.results = ss.ndict(type=ss.Result)
         self.log = InfectionLog()
-        self.new_cases_RNG = ss.MultiRNG(name=f'New cases of {self.name}')
+        if ss.options.multirng:
+            self.new_cases_RNG = ss.MultiRNG(name=f'New cases of {self.name}')
         return
 
     @property
@@ -136,6 +137,13 @@ class Disease(ss.Module):
         :raises: Exception if there are any invalid parameters (or if the initialization is otherwise invalid in some way)
         """
         pass
+
+    def _update_name(self, new_name):
+        """ Method to update name of a Disease instance if needed, and names of other objects that were
+        set up using the original's instance name."""
+        self.name = new_name
+        if ss.options.multirng:
+            self.new_cases_RNG.name = f"New cases of {new_name}"
 
     def set_initial_states(self, sim):
         """

--- a/starsim/diseases/examples.py
+++ b/starsim/diseases/examples.py
@@ -124,7 +124,7 @@ class SIR(Disease):
 
     def update_results(self, sim):
         super().update_results(sim)
-        self.results['prevalence'][sim.ti] = self.results.n_infected[sim.ti] / np.count_nonzero(sim.people.alive)
+        self.results['prevalence'][sim.ti] = self.results[f"n_{self.infected.name}"][sim.ti] / np.count_nonzero(sim.people.alive)
         return
 
 

--- a/starsim/diseases/examples.py
+++ b/starsim/diseases/examples.py
@@ -69,6 +69,7 @@ class SIR(Disease):
         super().update_death(sim, uids)
         self.infected[uids] = False
         self.recovered[uids] = False
+        self.susceptible[uids] = False
         return
 
     def validate_pars(self, sim):

--- a/starsim/modules.py
+++ b/starsim/modules.py
@@ -13,7 +13,7 @@ class Module(sc.prettyobj):
 
     def __init__(self, pars=None, name=None, label=None, requires=None, *args, **kwargs):
         self.pars = ss.omerge(pars)
-        self.name = name if name else self.__class__.__name__.lower() # Default name is the class name
+        self.name = ss.check_name(name) if name else self.__class__.__name__.lower() # Default name is the class name
         self.label = label if label else ''
         self.requires = sc.mergelists(requires)
         self.results = ss.ndict(type=ss.Result)

--- a/starsim/modules.py
+++ b/starsim/modules.py
@@ -81,6 +81,10 @@ class Module(sc.prettyobj):
                 self.results[reskey] = self.results[reskey]*sim.pars.pop_scale
         return
 
+    def _update_name(self, new_name):
+        """ Method to update name of an instance if needed"""
+        self.name = new_name
+
     @property
     def states(self):
         """

--- a/starsim/networks/randnet.py
+++ b/starsim/networks/randnet.py
@@ -21,6 +21,8 @@ class RandomNetwork(Network):
         super().__init__(**kwargs)
         if isinstance(n_contacts, rv_frozen):
             self.n_contacts = ss.ScipyDistribution(n_contacts, f'{self.__class__.__name__}_{self.name}_{self.label}')
+        else:
+            self.n_contacts = n_contacts
 
         self.dynamic = dynamic
 

--- a/starsim/settings.py
+++ b/starsim/settings.py
@@ -62,6 +62,14 @@ class Options(sc.objdict):
             centralized random number generator.'
         options.multirng = False
 
+        # NOTE-PSL: A temporary solution to accommodate development of multipathogen scenarios
+        optdesc.duplicates = 'Set True to enable automatic updating (enumerating) of \
+            the .name attribute of multiple instances of the same Module class, or \
+            of multiple instances of the State class. \
+            The default value is False, which means that an error will be raised by ss.utils.ndict()\
+            if it finds multiple instances with the identical names.'
+        options.duplicates = False
+
         optdesc.verbose = 'Set default level of verbosity (i.e. logging detail): e.g., 0.1 is an update every 10 simulated timesteps.'
         options.verbose = float(os.getenv('STARSIM_VERBOSE', 0.1))
 

--- a/starsim/sim.py
+++ b/starsim/sim.py
@@ -84,6 +84,7 @@ class Sim(sc.prettyobj):
         self.ti = 0  # The current time index
         self.validate_pars()  # Ensure parameters have valid values
         self.validate_dt()
+        self.validate_ndicts()  # Check for duplicate names in ndict attributes
         self.init_time_vecs()  # Initialize time vecs
         ss.set_seed(self.pars['rand_seed'])  # Reset the random seed before the population is created
         set_numba_seed(self.pars['rand_seed'])
@@ -231,6 +232,17 @@ class Sim(sc.prettyobj):
         self.people.year = self.year
         self.people.init_results(self)
         return self
+
+    def validate_ndicts(self):
+        """ Validate diseases, networks and connectors """
+
+        ndict_lst = [self.diseases, self.connectors, self.connectors]
+        for ndict_attr in ndict_lst:
+            names = [obj.name for _, obj in ndict_attr.items()]
+            if len(ndict_attr) > len(set(names)):
+                for key, obj in ndict_attr.items():
+                    # Update name of object with new keys from ndict
+                    obj._update_name(key)
 
     def init_demographics(self):
         for module in self.demographics.values():

--- a/starsim/sim.py
+++ b/starsim/sim.py
@@ -234,9 +234,9 @@ class Sim(sc.prettyobj):
         return self
 
     def validate_ndicts(self):
-        """ Validate diseases, networks and connectors """
+        """ Validate diseases, demographics and connectors """
 
-        ndict_lst = [self.diseases, self.connectors, self.connectors]
+        ndict_lst = [self.diseases, self.demographics, self.connectors]
         for ndict_attr in ndict_lst:
             names = [obj.name for _, obj in ndict_attr.items()]
             if len(ndict_attr) > len(set(names)):

--- a/starsim/states.py
+++ b/starsim/states.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 import sciris as sc
 import numba as nb
-from starsim.utils import INT_NAN
+from starsim.utils import INT_NAN, check_name
 from starsim.distributions import ScipyDistribution
 from starsim.utils import warn
 from numpy.lib.mixins import NDArrayOperatorsMixin  # Inherit from this to automatically gain operators like +, -, ==, <, etc.
@@ -353,7 +353,7 @@ class State(FusedArray):
         self.fill_value = fill_value
 
         self._data = DynamicView(dtype=dtype)
-        self.name = name
+        self.name = check_name(name)
         self.label = label or name
         self.values = self._data._view
         self._initialized = False

--- a/starsim/utils.py
+++ b/starsim/utils.py
@@ -43,11 +43,11 @@ class ndict(sc.objdict):
 
     """
 
-    def __init__(self, *args, name='name', type=None, strict=True, duplicates=ss.options.duplicates, **kwargs):
+    def __init__(self, *args, name='name', type=None, strict=True, duplicates=None, **kwargs):
         self.setattribute('_name', name)  # Since otherwise treated as keys
         self.setattribute('_type', type)
         self.setattribute('_strict', strict)
-        self.setattribute('_duplicates', duplicates)
+        self.setattribute('_duplicates', ss.options.duplicates)
 
         self._initialize(*args, **kwargs)
         return

--- a/starsim/utils.py
+++ b/starsim/utils.py
@@ -171,6 +171,10 @@ def check_name(name, n_suggest=5):
     Check whether a string in `name` is a valid Python identifier and
     suggests a new name if it is not.
 
+    NOTE: This function was written considering that users can provide/set the
+    name attribute of instances of Modules, States, Networks, etc, and they
+    may provide invalid Python identifiers, which can break dot notation.
+
     Args:
         name (str): The string attribute to use as keys.
         n_suggest (int): Maximum number of suggestions to return by sc.suggest()

--- a/starsim/utils.py
+++ b/starsim/utils.py
@@ -72,6 +72,17 @@ class ndict(sc.objdict):
 
         if valid is True:
             self._check_type(arg)
+            # Check if this key already exists
+            if key in self:
+                i = 1  # 1-based indexing seems appropriate here
+                new_key = f'{key}{i}'
+                # Find what's the next number we need to use for the new key
+                while new_key in self:
+                    i += 1
+                    new_key = f'{key}{i}'
+                warnmsg = f'Warning: duplicated name ({key}). Updated to {new_key}'  # Mssg can be removed
+                warn(warnmsg, die=False)
+                key = new_key
             self[key] = arg
         elif valid is None:
             pass  # Nothing to do

--- a/starsim/version.py
+++ b/starsim/version.py
@@ -5,5 +5,5 @@ Version and license information.
 __all__ = ['__version__', '__versiondate__', '__license__']
 
 __version__ = '0.1.8'
-__versiondate__ = '2024-01-30'
-__license__ = f'STIsim {__version__} ({__versiondate__}) — © 2024 by IDM'
+__versiondate__ = '2024-02-09'
+__license__ = f'starsim {__version__} ({__versiondate__}) — © 2024 by IDM'

--- a/tests/test_multivariant.py
+++ b/tests/test_multivariant.py
@@ -1,0 +1,40 @@
+"""
+Run simple test with multiple instances of the same Disease. Shows how duplicate names are handled.
+"""
+
+# %% Imports and settings
+import starsim as ss
+import scipy.stats as sps
+
+
+def test_sir_vs_sir(sir0, sir1):
+
+    ppl = ss.People(100)
+    ppl.networks = ss.ndict(ss.RandomNetwork(n_contacts=sps.poisson(mu=4)))
+
+
+    # Sim
+    sim = ss.Sim(people=ppl, diseases=[sir0, sir1])
+    sim.run()
+
+    return sim
+
+
+def test_sims(duplicates=None):
+    ss.options(duplicates=duplicates) # default
+    try:
+        test_sir_vs_sir(ss.SIR({'dur_inf': sps.norm(loc=10)}),
+                        ss.SIR({'dur_inf': sps.norm(loc=2)}))
+    except Exception as e:
+        print(f"Exception: {str(e)}")
+
+    try:
+        test_sir_vs_sir(ss.SIR({'dur_inf': sps.norm(loc=10)}, name="sir0"),
+                        ss.SIR({'dur_inf': sps.norm(loc=2)}, name="sir1"))
+    except Exception as e:
+        print(f"Exception: {str(e)}")
+
+
+if __name__ == '__main__':
+    test_sims(duplicates=False) # Default
+    test_sims(duplicates=True)


### PR DESCRIPTION

This PR introduces improvements in the handling of objects that have identical `name` attribute. Along with these updates, it validates identifiers in the `name` attribute to avoid any potential user-defined naming conflicts that could interfere with dot notation usage in 'sim' and 'people' - and potentially elsewhere. 


The main motivation behind these fixes was the development of pathogen-pathogen interactions (connectors) specifically thinking of scenarios where multiple variants of the same pathogen family circulate (ie, multiple independent instances of the same Disease class). 

These fixes are intended as a workaround current limitations, to enable further R&D on connectors, until a more general solution for handling duplicate names is implemented. 


***

With the changes introduced, by default, this simulation will fail with an informative error message ([DuplicateNameException](https://github.com/amath-idm/starsim/blob/fixes/duplicate-validate-names/starsim/utils.py#L482))

```python
    ppl = ss.People(100)
    ppl.networks = ss.ndict(ss.RandomNetwork(n_contacts=sps.poisson(mu=4)))


    # Disease 1
    sir0_pars = {'dur_inf': sps.norm(loc=10)}
    sir0 = ss.SIR(sir0_pars)

    # Disease 2
    sir1_pars = {'dur_inf': sps.norm(loc=2)}
    sir1 = ss.SIR(sir1_pars)


    # Sim
    sim = ss.Sim(people=ppl, diseases=[sir0, sir1])
    sim.run() 

```
Error:
```
starsim.utils.DuplicateNameException: A <class 'starsim.diseases.examples.SIR'> with name `sir` has already been added.
```

And so will this simulation

```python
    ppl = ss.People(100)
    ppl.networks = ss.ndict(ss.RandomNetwork(n_contacts=sps.poisson(mu=4)))


    # Disease 1
    sir0_pars = {'dur_inf': sps.norm(loc=10)}
    sir0 = ss.SIR(sir0_pars, name="sir0")

    # Disease 2
    sir1_pars = {'dur_inf': sps.norm(loc=2)}
    sir1 = ss.SIR(sir1_pars, name="sir1")


    # Sim
    sim = ss.Sim(people=ppl, diseases=[sir0, sir1])
    sim.run() 
```

Error:
```
starsim.utils.DuplicateNameException: A <class 'starsim.states.State'> with name `susceptible` has already been added.
```


But if we run these snippets them with `ss.options(duplicates=True)` -- happy to rename this to something else --, 
- ndict() will accept multiple objects with the same name attribute and [generate a new key](https://github.com/amath-idm/starsim/blob/fixes/duplicate-validate-names/starsim/utils.py#L80) for the duplicates (achieves this by enumerating) 
- [sim.validate_ndicts()](https://github.com/amath-idm/starsim/blob/fixes/duplicate-validate-names/starsim/sim.py#L236) will update the module names based on the new keys from ndict.

Related issues:
- #231 
- #234 (temporary workaround) 
- #260 
