### PR TITLE
Three bug fixes

### DIFF
--- a/starsim/demographics.py
+++ b/starsim/demographics.py
@@ -308,9 +308,9 @@ class Pregnancy(BaseDemographics):
 
             # Process age data
             age_bins = df[age_label].unique()
-            age_bins = np.append(age_bins, 1000)
+            age_bins = np.append(age_bins, age_bins[-1]+1) # WARNING: Assumes one year age bins! TODO: More robust handling.
             age_inds = np.digitize(sim.people.age[uids], age_bins) - 1
-            age_inds[age_inds >= len(age_bins)-2] = -1  # This ensures women outside the data range will get a value of 0
+            age_inds[age_inds == len(age_bins)-1] = -1  # This ensures women outside the data range will get a value of 0
 
             # Adjust rates: rates are based on the entire population, but we need to remove
             # anyone already pregnant and then inflate the rates for the remainder

--- a/starsim/demographics.py
+++ b/starsim/demographics.py
@@ -308,9 +308,9 @@ class Pregnancy(BaseDemographics):
 
             # Process age data
             age_bins = df[age_label].unique()
-            age_bins = np.append(age_bins, 50)
+            age_bins = np.append(age_bins, 1000)
             age_inds = np.digitize(sim.people.age[uids], age_bins) - 1
-            age_inds[age_inds >= max(age_inds)] = -1  # This ensures women outside the data range will get a value of 0
+            age_inds[age_inds >= len(age_bins)-2] = -1  # This ensures women outside the data range will get a value of 0
 
             # Adjust rates: rates are based on the entire population, but we need to remove
             # anyone already pregnant and then inflate the rates for the remainder

--- a/starsim/distributions.py
+++ b/starsim/distributions.py
@@ -11,7 +11,7 @@ from starsim.random import SingleRNG, MultiRNG
 from starsim import options
 from scipy.stats import (bernoulli, expon, lognorm, norm, poisson, randint, rv_discrete, 
                          uniform, rv_histogram, weibull_min)
-from scipy.stats._discrete_distns import bernoulli_gen # TODO: can we remove this?
+from scipy.stats._discrete_distns import bernoulli_gen, poisson_gen # TODO: can we remove this?
 
 
 __all__ = ['ScipyDistribution', 'ScipyHistogram']

--- a/starsim/distributions.py
+++ b/starsim/distributions.py
@@ -178,7 +178,7 @@ class ScipyDistribution():
                                 pars_slots[repeat_slot_u] = kwargs_pname # Take first instance of each
                                 kwargs[pname] = pars_slots
 
-                        vals = self.rvs_fix_bernoulli(*args, **kwargs)
+                        vals = self.rvs_crn(*args, **kwargs)
                         repeat_slot_vals[cur_inds] = vals[repeat_slot_u]
                         todo_inds = np.where(np.isnan(repeat_slot_vals))[0]
 

--- a/starsim/sim.py
+++ b/starsim/sim.py
@@ -189,7 +189,7 @@ class Sim(sc.prettyobj):
         """
         Construct vectors things that keep track of time
         """
-        self.yearvec = np.arange(start=self.pars.start, stop=self.pars.end + self.pars.dt, step=self.pars.dt)  # Includes all the timepoints in the last year
+        self.yearvec = np.arange(start=self.pars.start, stop=self.pars.end + self.pars.dt, step=self.pars.dt)
         self.npts = len(self.yearvec)
         self.tivec = np.arange(self.npts)
         return

--- a/starsim/sim.py
+++ b/starsim/sim.py
@@ -189,7 +189,7 @@ class Sim(sc.prettyobj):
         """
         Construct vectors things that keep track of time
         """
-        self.yearvec = np.arange(start=self.pars.start, stop=self.pars.end + 1, step=self.pars.dt)  # Includes all the timepoints in the last year
+        self.yearvec = np.arange(start=self.pars.start, stop=self.pars.end + self.pars.dt, step=self.pars.dt)  # Includes all the timepoints in the last year
         self.npts = len(self.yearvec)
         self.tivec = np.arange(self.npts)
         return

--- a/tests/baseline.json
+++ b/tests/baseline.json
@@ -1,17 +1,17 @@
 {
   "summary": {
-    "n_alive": 9661.44761904762,
-    "new_deaths": 7.076190476190476,
-    "cum_deaths": 736.0,
+    "n_alive": 9673.058823529413,
+    "new_deaths": 6.990196078431373,
+    "cum_deaths": 707.0,
     "pregnancy_pregnancies": 0.0,
     "pregnancy_births": 0.0,
     "pregnancy_cbr": 0.0,
     "hiv_n_on_art": 0.0,
-    "hiv_n_susceptible": 8881.438095238096,
-    "hiv_n_infected": 780.0095238095238,
-    "hiv_prevalence": 0.08081250879044433,
-    "hiv_new_infections": 14.723809523809523,
-    "hiv_cum_infections": 1540.0,
-    "hiv_new_deaths": 7.076190476190476
+    "hiv_n_susceptible": 8893.872549019608,
+    "hiv_n_infected": 779.1862745098039,
+    "hiv_prevalence": 0.0806248275622018,
+    "hiv_new_infections": 15.049019607843137,
+    "hiv_cum_infections": 1532.0,
+    "hiv_new_deaths": 6.990196078431373
   }
 }

--- a/tests/benchmark.json
+++ b/tests/benchmark.json
@@ -2,12 +2,12 @@
   "time": {
     "people": 0.003,
     "initialize": 0.014,
-    "run": 0.168
+    "run": 0.155
   },
   "parameters": {
     "n_agents": 10000,
     "n_years": 20,
     "dt": 0.2
   },
-  "cpu_performance": 0.7758325385274683
+  "cpu_performance": 0.7936101956793515
 }


### PR DESCRIPTION
1. Bernoulli (binomial) random variables don't use a random number when p=0, throwing off CRN. Small/hacky fix for that issue.
2. In demographics, better handling of age bins that was causing a bug in some cases.
3. Correct length of sim yearvec for dt != 1.