### PR TITLE
Remove bernoulli from par_dists

### DIFF
--- a/starsim/demographics.py
+++ b/starsim/demographics.py
@@ -147,10 +147,6 @@ class Deaths(Demographics):
             units = 1e-3,  # assumes death rates are per 1000. If using percentages, switch this to 1
         )
 
-        self.par_dists = ss.omergeleft(par_dists,
-            death_rate = ss.bernoulli
-        )
-
         # Process metadata. Defaults here are the labels used by UN data
         self.metadata = ss.omergeleft(metadata,
             data_cols = dict(year='Time', sex='Sex', age='AgeGrpStart', value='mx'),
@@ -160,7 +156,7 @@ class Deaths(Demographics):
         # Process data, which may be provided as a number, dict, dataframe, or series
         # If it's a number it's left as-is; otherwise it's converted to a dataframe
         self.death_rate_data = self.standardize_death_data()
-        self.pars.death_rate = self.make_death_prob_fn
+        self.pars.death_rate = ss.bernoulli(p=self.make_death_prob_fn)
 
         return
 
@@ -267,11 +263,8 @@ class Pregnancy(Demographics):
             units = 1e-3,          # Assumes fertility rates are per 1000. If using percentages, switch this to 1
         )
 
-        self.par_dists = ss.omergeleft(par_dists,
-            fertility_rate = ss.bernoulli,
-            maternal_death_rate = ss.bernoulli,
-            sex_ratio = ss.bernoulli
-        )
+        self.pars.maternal_death_rate = ss.bernoulli(self.pars.maternal_death_rate)
+        self.pars.sex_ratio = ss.bernoulli(self.pars.sex_ratio)
 
         # Process metadata. Defaults here are the labels used by UN data
         self.metadata = ss.omergeleft(metadata,
@@ -283,7 +276,7 @@ class Pregnancy(Demographics):
         # Process data, which may be provided as a number, dict, dataframe, or series
         # If it's a number it's left as-is; otherwise it's converted to a dataframe
         self.fertility_rate_data = self.standardize_fertility_data()
-        self.pars.fertility_rate = self.make_fertility_prob_fn
+        self.pars.fertility_rate = ss.bernoulli(p=self.make_fertility_prob_fn)
 
         return
 

--- a/starsim/disease.py
+++ b/starsim/disease.py
@@ -177,7 +177,7 @@ class Infection(Disease):
     operate on to capture co-infection
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, pars, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.add_states(
             ss.State('susceptible', bool, True),
@@ -186,6 +186,12 @@ class Infection(Disease):
             ss.State('rel_trans', float, 1.0),
             ss.State('ti_infected', int, ss.INT_NAN),
         )
+
+        self.pars = ss.omergeleft(pars,
+            init_prev = 0,
+        )
+
+        self.pars.init_prev = ss.bernoulli(self.pars.init_prev)
 
         self.rng_target = ss.random(name='target')
         self.rng_source = ss.random(name='source')

--- a/starsim/diseases/cholera.py
+++ b/starsim/diseases/cholera.py
@@ -44,16 +44,15 @@ class Cholera(ss.Infection):
             dur_asymp2rec  = ss.uniform,
             dur_symp2rec   = ss.lognorm_ex,
             dur_symp2dead  = ss.lognorm_ex,
-            init_prev      = ss.bernoulli,
-            p_death        = ss.bernoulli,
-            p_symp         = ss.bernoulli,
-            p_env_transmit = ss.bernoulli,
         )
 
         super().__init__(pars=pars, par_dists=par_dists, *args, **kwargs)
 
+        self.pars.p_death        = ss.bernoulli(self.pars.p_death)
+        self.pars.p_symp         = ss.bernoulli(self.pars.p_symp)
+        self.pars.p_env_transmit = ss.bernoulli(self.pars.p_env_transmit)
+
         # Boolean states
-        
         self.add_states(
             # Susceptible & infected are added automatically, here we add the rest
             ss.State('exposed', bool, False),

--- a/starsim/diseases/ebola.py
+++ b/starsim/diseases/ebola.py
@@ -42,13 +42,12 @@ class Ebola(SIR):
             dur_dead2buried = ss.lognorm_ex,
             dur_symp2rec    = ss.lognorm_ex,
             dur_sev2rec     = ss.lognorm_ex,
-            p_sev           = ss.bernoulli,
-            p_death         = ss.bernoulli,
-            p_safe_bury     = ss.bernoulli,
-            init_prev       = ss.bernoulli,
         )
 
         super().__init__(pars=pars, par_dists=par_dists, *args, **kwargs)
+
+        self.pars.p_sev           = ss.bernoulli(self.pars.p_sev)
+        self.pars.p_safe_bury     = ss.bernoulli(self.pars.p_safe_bury)
 
         # Boolean states
         

--- a/starsim/diseases/gonorrhea.py
+++ b/starsim/diseases/gonorrhea.py
@@ -30,12 +30,12 @@ class Gonorrhea(ss.Infection):
 
         par_dists = ss.omergeleft(par_dists,
             dur_inf_in_days = ss.lognorm_ex,
-            p_symp          = ss.bernoulli,
-            p_clear         = ss.bernoulli,
-            init_prev       = ss.bernoulli,
         )
 
         super().__init__(pars=pars, par_dists=par_dists, *args, **kwargs)
+
+        self.pars.p_symp          = ss.bernoulli(self.pars.p_symp)
+        self.pars.p_clear         = ss.bernoulli(self.pars.p_clear)
         return
 
     def init_results(self, sim):

--- a/starsim/diseases/hiv.py
+++ b/starsim/diseases/hiv.py
@@ -30,14 +30,10 @@ class HIV(ss.Infection):
             death_prob = 0.05,
         )
 
-        par_dists = ss.omergeleft(par_dists,
-            init_prev  = ss.bernoulli,
-            death_prob = ss.bernoulli,
-        )
-
         super().__init__(pars=pars, par_dists=par_dists, *args, **kwargs)
+
         self.death_prob_data = sc.dcp(self.pars.death_prob)
-        self.pars.death_prob = self.make_death_prob
+        self.pars.death_prob = ss.bernoulli(p=self.make_death_prob)
 
         return
 

--- a/starsim/diseases/measles.py
+++ b/starsim/diseases/measles.py
@@ -30,8 +30,6 @@ class Measles(SIR):
         par_dists = ss.omergeleft(par_dists,
             dur_exp   = ss.normal,
             dur_inf   = ss.normal,
-            init_prev = ss.bernoulli,
-            p_death   = ss.bernoulli,
         )
 
         super().__init__(pars=pars, par_dists=par_dists, *args, **kwargs)

--- a/starsim/diseases/sir.py
+++ b/starsim/diseases/sir.py
@@ -27,11 +27,11 @@ class SIR(ss.Infection):
 
         par_dists = ss.omergeleft(par_dists,
             dur_inf   = ss.lognorm_ex,
-            init_prev = ss.bernoulli,
-            p_death   = ss.bernoulli,
         )
 
         super().__init__(pars=pars, par_dists=par_dists, *args, **kwargs)
+
+        self.pars.p_death = ss.bernoulli(self.pars.p_death)
 
         self.add_states(
             ss.State('recovered', bool, False),
@@ -108,9 +108,8 @@ class SIS(ss.Infection):
 
         par_dists = ss.omergeleft(par_dists,
             dur_inf   = ss.lognorm_ex,
-            init_prev = ss.bernoulli,
         )
-        
+
         self.add_states(
             ss.State('ti_recovered', int, ss.INT_NAN),
             ss.State('immunity', float, 0.0),

--- a/starsim/network.py
+++ b/starsim/network.py
@@ -537,7 +537,6 @@ class MFNet(SexualNetwork, DynamicNetwork):
 
         par_dists = ss.omergeleft(par_dists,
             duration      = ss.lognorm_ex,
-            participation = ss.bernoulli,
             debut         = ss.normal,
             acts          = ss.poisson,
         )
@@ -545,6 +544,7 @@ class MFNet(SexualNetwork, DynamicNetwork):
         DynamicNetwork.__init__(self, key_dict=key_dict, **kwargs)
         SexualNetwork.__init__(self, pars, key_dict=key_dict, **kwargs)
 
+        self.pars.participation = ss.bernoulli(self.pars.participation)
         self.dist = ss.choice(name='MFNet', replace=False) # Set the array later
         self.par_dists = par_dists
 
@@ -811,12 +811,22 @@ class HPVNet(MFNet):
 
         self.par_dists = ss.omergeleft(par_dists,
             duration      = ss.lognorm,
-            participation = ss.bernoulli,
             debut         = ss.norm,
             acts          = ss.lognorm,
-            cross_layer   = ss.bernoulli,
-            concurrency   = ss.bernoulli,
         )
+
+        self.pars.participation = ss.bernoulli(self.pars.participation)
+        self.pars.cross_layer = ss.bernoulli(self.pars.participatiocross_layern)
+        self.pars.concurrency = ss.bernoulli(self.pars.concurrency)
+
+        DynamicNetwork.__init__(self, key_dict=key_dict, **kwargs)
+        SexualNetwork.__init__(self, pars, key_dict=key_dict, **kwargs)
+
+        self.dist = ss.choice(name='MFNet', replace=False) # Set the array later
+
+        return
+
+    def initialize(self, sim):
 
         key_dict = dict(
             acts = ss_float_,

--- a/tests/baseline.json
+++ b/tests/baseline.json
@@ -1,17 +1,17 @@
 {
   "summary": {
-    "n_alive": 9648.460784313726,
-    "new_deaths": 7.549019607843137,
-    "cum_deaths": 760.0,
+    "n_alive": 9649.960784313726,
+    "new_deaths": 7.196078431372549,
+    "cum_deaths": 726.0,
     "pregnancy_pregnancies": 0.0,
     "pregnancy_births": 0.0,
     "pregnancy_cbr": 0.0,
     "hiv_n_on_art": 0.0,
-    "hiv_n_susceptible": 8781.696078431372,
-    "hiv_n_infected": 866.7647058823529,
-    "hiv_prevalence": 0.08997817294776833,
-    "hiv_new_infections": 16.84313725490196,
-    "hiv_cum_infections": 1710.0,
-    "hiv_new_deaths": 7.549019607843137
+    "hiv_n_susceptible": 8854.754901960785,
+    "hiv_n_infected": 795.2058823529412,
+    "hiv_prevalence": 0.08246831695747922,
+    "hiv_new_infections": 15.42156862745098,
+    "hiv_cum_infections": 1568.0,
+    "hiv_new_deaths": 7.196078431372549
   }
 }

--- a/tests/benchmark.json
+++ b/tests/benchmark.json
@@ -1,13 +1,13 @@
 {
   "time": {
-    "people": 0.001,
-    "initialize": 0.024,
-    "run": 0.317
+    "people": 0.002,
+    "initialize": 0.025,
+    "run": 0.263
   },
   "parameters": {
     "n_agents": 10000,
     "n_years": 20,
     "dt": 0.2
   },
-  "cpu_performance": 0.9742670153979531
+  "cpu_performance": 0.8529125884813947
 }


### PR DESCRIPTION
* Remove bernoulli from par_dists. There is no need to have bernoulli in `par_dists` as these _must_ be bernoulli. Hard coding to avoid potential mistakes.

* Removed duplicate states

* Lifted `init_prev` to Infection, which caused a stochastic change, so new baselines.

Related to #354