### PR TITLE
Fix type conversion in age_props

### DIFF
--- a/starsim/people.py
+++ b/starsim/people.py
@@ -214,7 +214,7 @@ class People(BasePeople):
         if sc.checktype(age_data, pd.DataFrame):
             age_bins = age_data['age'].values
             age_props = age_data['value'].values
-            age_props /= age_props.sum()
+            age_props = age_props / age_props.sum()
             return ss.choice(a=age_bins, p=age_props)
 
 


### PR DESCRIPTION
Trivial one-line change to avoid a warning (or error?) in converting int to float.