### PR TITLE
Restoring the ability to use a centralized RNG

### DIFF
--- a/starsim/demographics.py
+++ b/starsim/demographics.py
@@ -451,14 +451,14 @@ class Pregnancy(Demographics):
         self.ti_pregnant[uids] = sim.ti
 
         # Outcomes for pregnancies
-        dur = np.full(len(uids), sim.ti + self.pars.dur_pregnancy / sim.dt)
+        dur_preg = np.full(len(uids), self.pars.dur_pregnancy / sim.dt)
+        dur_postpartum = np.full(len(uids), self.pars.dur_postpartum / sim.dt)
         dead = self.pars.maternal_death_rate.rvs(uids)
-        self.ti_delivery[uids] = dur  # Currently assumes maternal deaths still result in a live baby
-        dur_post_partum = np.full(len(uids), dur + self.pars.dur_postpartum / sim.dt)
-        self.ti_postpartum[uids] = dur_post_partum
+        self.ti_delivery[uids] = sim.ti + dur_preg # Currently assumes maternal deaths still result in a live baby
+        self.ti_postpartum[uids] = sim.ti + dur_preg + dur_postpartum
 
         if np.any(dead): # NB: 100x faster than np.sum(), 10x faster than np.count_nonzero()
-            self.ti_dead[uids[dead]] = dur[dead]
+            self.ti_dead[uids[dead]] = sim.ti + dur_preg[dead]
         return
 
     def update_results(self, sim):

--- a/starsim/distributions.py
+++ b/starsim/distributions.py
@@ -218,7 +218,7 @@ class Dist: # TODO: figure out why subclassing sc.prettyobj breaks isinstance
 
     @property
     def bitgen(self):
-        try:    return self.rng.bit_generator
+        try:    return self.rng._bit_generator
         except: return None
     
     @property
@@ -265,7 +265,7 @@ class Dist: # TODO: figure out why subclassing sc.prettyobj breaks isinstance
         """
         if not isinstance(state, dict):
             state = self.history[state]
-        self.rng.bit_generator.state = state.copy()
+        self.rng._bit_generator.state = state.copy()
         self.ready = True
         return self.state
 
@@ -289,7 +289,10 @@ class Dist: # TODO: figure out why subclassing sc.prettyobj breaks isinstance
         self.process_seed(trace, seed)
         
         # Create the actual RNG
-        self.rng = np.random.default_rng(seed=self.seed)
+        if ss.options._centralized:
+            self.rng = np.random.mtrand._rand
+        else:
+            self.rng = np.random.default_rng(seed=self.seed)
         self.make_history(reset=True)
         
         # Handle the sim, module, and slots

--- a/starsim/settings.py
+++ b/starsim/settings.py
@@ -77,6 +77,9 @@ class Options(sc.objdict):
         optdesc.precision = 'Set arithmetic precision -- 32-bit by default for efficiency'
         options.precision = int(os.getenv('STARSIM_PRECISION', 64))
 
+        optdesc._centralized = 'If True, revert to centralized random number generation (NOT ADVISED).'
+        options._centralized = False
+
         return optdesc, options
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
Restoring the ability to use a centralized random number generator, as needed for the CRN publication. Can remove later.