### PR TITLE
Change RandomNet edge duration

### DIFF
--- a/starsim/network.py
+++ b/starsim/network.py
@@ -434,7 +434,7 @@ class RandomNet(DynamicNetwork):
         """ Initialize """
         pars = ss.omerge({
             'n_contacts': 10,  # Distribution or int. If int, interpreted as the mean of the dist listed in par_dists
-            'dur': 1,
+            'dur': 0,
         }, pars)
 
         super().__init__(pars=pars, key_dict=key_dict, **kwargs)


### PR DESCRIPTION
Important change to the duration of edges in RandomNet. Results using RandomNet will change as the default edge duration has changed from one year to zero, which means one time step. 

The implementation still needs a rework so that results do not vary with dt.