### PR TITLE
Multiple interventions using the same product

### DIFF
--- a/starsim/modules.py
+++ b/starsim/modules.py
@@ -108,6 +108,10 @@ class Module(sc.quickobj):
             state.initialize(sim)
 
         self.initialized = True
+
+        # Add module states to the People's dicts
+        sim.people.add_module(self)
+        
         return
 
     def finalize(self, sim):

--- a/starsim/products.py
+++ b/starsim/products.py
@@ -12,6 +12,11 @@ __all__ = ['Product', 'Dx', 'Tx', 'Vx']
 
 class Product(ss.Module):
     """ Generic product implementation """
+    def initialize(self, sim):
+        if not self.initialized:
+            super().initialize(sim)
+        else:
+            return
 
     def administer(self, people, inds):
         """ Adminster a Product - implemented by derived classes """

--- a/starsim/sim.py
+++ b/starsim/sim.py
@@ -359,9 +359,6 @@ class Sim(sc.prettyobj):
             self.pars[disease.name] = disease.pars
             self.results[disease.name] = disease.results
 
-            # Add disease states to the People's dicts
-            self.people.add_module(disease)
-
         # Store diseases in the sim
         self.diseases = ss.ndict(*diseases)
 
@@ -410,14 +407,9 @@ class Sim(sc.prettyobj):
             self.pars[intervention.name] = intervention.pars
             self.results[intervention.name] = intervention.results
 
-            # Add intervention states to the People's dicts
-            self.people.add_module(intervention)
-
             # If there's a product module present, initialize and add it
             if hasattr(intervention, 'product') and isinstance(intervention.product, ss.Product):
                 intervention.product.initialize(self)
-
-                self.people.add_module(intervention.product)
         
         # TODO: combine this with the code above
         for k,intervention in self.interventions.items():


### PR DESCRIPTION
I ran into issues with multiple interventions using the same product. For each intervention using that product, it was previously trying to initialize the product and add it to the people class. 
I added a `def initialize(self, sim)` method to the `ss.Product` class to ensure the product only gets initialized once.
And I moved `self.people.add_module(intervention)` to the module initialization and removed it from `sim.py`. This way, the module is responsible for adding itself to the people class. 