### PR TITLE
Prenatal and postnatal transmission

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ What's new
 All notable changes to the codebase are documented in this file. Changes that may result in differences in model output, or are required in order to run an old parameter set with the current version, are flagged with the term "Regression information".
 
 
+Version 0.5.1 (2024-05-15)
+--------------------------
+- Separates maternal transmission into prenatal and postnatal modules
+- *GitHub info*: PR `509 <https://github.com/starsimhub/starsim/pull/509>`_
+
+
+
+
 Version 0.5.0 (2024-05-14)
 --------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,6 @@ Version 0.5.1 (2024-05-15)
 - *GitHub info*: PR `509 <https://github.com/starsimhub/starsim/pull/509>`_
 
 
-
-
 Version 0.5.0 (2024-05-14)
 --------------------------
 

--- a/starsim/demographics.py
+++ b/starsim/demographics.py
@@ -305,7 +305,6 @@ class Pregnancy(Demographics):
 
         if sc.isnumber(self.fertility_rate_data):
             fertility_rate = pd.Series(index=uids, data=self.fertility_rate_data)
-            fertility_rate[self.pregnant.uids] = 0
 
         else:
             # Abbreviate key variables
@@ -342,10 +341,10 @@ class Pregnancy(Demographics):
             # Make array of fertility rates
             fertility_rate = pd.Series(index=uids)
             fertility_rate[uids] = new_percent[age_inds]
-            fertility_rate[pregnant_uids] = 0
 
         # Scale from rate to probability. Consider an exponential here.
         fertility_prob = fertility_rate * (self.pars.units * self.pars.rel_fertility * sim.pars.dt)
+        fertility_prob[self.pregnant.uids] = 0 # Currently pregnant women cannot become pregnant again
         fertility_prob = np.clip(fertility_prob, a_min=0, a_max=1)
 
         return fertility_prob
@@ -411,9 +410,6 @@ class Pregnancy(Demographics):
                 if not np.array_equal(new_mother_uids, deliveries.uids):
                     errormsg = f'IDs of new mothers do not match IDs of new deliveries.'
                     raise ValueError(errormsg)
-                if len(new_mother_uids) != len(new_infant_uids):
-                    errormsg = f'Number of new mothers ({len(deliveries.uids)}) does not match number of new infants ({len(new_infant_uids)})in the postnatal network.'
-                    raise ValueError(errormsg)
 
                 # Create durations and start dates, and add connections
                 durs = self.dur_postpartum[new_mother_uids]
@@ -444,6 +440,7 @@ class Pregnancy(Demographics):
         if np.any(self.pregnant[conceive_uids]):
             which_uids = conceive_uids[self.pregnant[conceive_uids]]
             errormsg = f'New conceptions registered in {len(which_uids)} pregnant agent(s) at timestep {self.sim.ti}.'
+            raise ValueError(errormsg)
 
         # Set prognoses for the pregnancies
         if len(conceive_uids) > 0:

--- a/starsim/disease.py
+++ b/starsim/disease.py
@@ -270,10 +270,7 @@ class Infection(Disease):
 
                 # Calculate probability of a->b transmission.
                 beta_per_dt = net.beta_per_dt(disease_beta=beta, dt=self.sim.dt)
-                try:
-                    p_transmit = rel_trans[src] * rel_sus[trg] * beta_per_dt
-                except:
-                    import traceback; traceback.print_exc(); import pdb; pdb.set_trace()
+                p_transmit = rel_trans[src] * rel_sus[trg] * beta_per_dt
 
                 # Generate a new random number based on the two other random numbers -- 3x faster than `rvs = np.remainder(rvs_s + rvs_t, 1)`
                 rvs_s = self.rng_source.rvs(src)

--- a/starsim/disease.py
+++ b/starsim/disease.py
@@ -270,7 +270,10 @@ class Infection(Disease):
 
                 # Calculate probability of a->b transmission.
                 beta_per_dt = net.beta_per_dt(disease_beta=beta, dt=self.sim.dt)
-                p_transmit = rel_trans[src] * rel_sus[trg] * beta_per_dt
+                try:
+                    p_transmit = rel_trans[src] * rel_sus[trg] * beta_per_dt
+                except:
+                    import traceback; traceback.print_exc(); import pdb; pdb.set_trace()
 
                 # Generate a new random number based on the two other random numbers -- 3x faster than `rvs = np.remainder(rvs_s + rvs_t, 1)`
                 rvs_s = self.rng_source.rvs(src)

--- a/starsim/network.py
+++ b/starsim/network.py
@@ -811,6 +811,7 @@ class MaternalNet(DynamicNetwork):
         if mother_inds is None:
             return 0
         else:
+            if start is None: start = np.full_like(dur, fill_value=self.sim.ti)
             n = len(mother_inds)
             beta = np.ones(n)
             end=start+dur/self.sim.dt

--- a/starsim/network.py
+++ b/starsim/network.py
@@ -786,7 +786,7 @@ class MaternalNet(Network):
         """
         Initialized empty and filled with pregnancies throughout the simulation
         """
-        key_dict = sc.mergedicts({'dur': ss_float_}, key_dict)
+        key_dict = sc.mergedicts({'dur': ss_float_, 'start': ss_int_, 'end': ss_int_}, key_dict)
         super().__init__(key_dict=key_dict, prenatal=prenatal, postnatal=postnatal, **kwargs)
         return
 
@@ -796,19 +796,20 @@ class MaternalNet(Network):
         Keep connections for now, might want to consider removing
         """
         dt = self.sim.dt
-        self.contacts.dur = self.contacts.dur/dt - dt
+        self.contacts.dur = self.contacts.dur - dt
         inactive = self.contacts.dur <= 0
         self.contacts.beta[inactive] = 0
         return
 
-    def add_pairs(self, mother_inds=None, unborn_inds=None, dur=None):
+    def add_pairs(self, mother_inds=None, unborn_inds=None, dur=None, start=None):
         """ Add connections between pregnant women and their as-yet-unborn babies """
         if mother_inds is None:
             return 0
         else:
             n = len(mother_inds)
             beta = np.ones(n)
-            self.append(p1=mother_inds, p2=unborn_inds, beta=beta, dur=dur)
+            end=start+dur/self.sim.dt
+            self.append(p1=mother_inds, p2=unborn_inds, beta=beta, dur=dur, start=start, end=end)
             return n
 
 

--- a/starsim/network.py
+++ b/starsim/network.py
@@ -72,7 +72,7 @@ class Network(ss.Module):
         )
         self.meta = sc.mergedicts(default_keys, key_dict)
         self.prenatal = prenatal  # Prenatal connections are added at the time of conception. Requires ss.Pregnancy()
-        self.postnatal = postnatal  # Ppstnatal connections are added at the time of delivery. Requires ss.Pregnancy()
+        self.postnatal = postnatal  # Postnatal connections are added at the time of delivery. Requires ss.Pregnancy()
 
         # Initialize the keys of the network
         self.contacts = sc.objdict()
@@ -786,7 +786,7 @@ class MaternalNet(DynamicNetwork):
         """
         Initialized empty and filled with pregnancies throughout the simulation
         """
-        key_dict = sc.mergedicts({'dur': ss_float_, 'start': ss_int_, 'end': ss_int_}, key_dict)
+        key_dict = sc.mergedicts(dict(dur=ss_float_, start=ss_int_, end=ss_int_), key_dict)
         super().__init__(key_dict=key_dict, prenatal=prenatal, postnatal=postnatal, **kwargs)
         return
 
@@ -814,23 +814,19 @@ class MaternalNet(DynamicNetwork):
             if start is None: start = np.full_like(dur, fill_value=self.sim.ti)
             n = len(mother_inds)
             beta = np.ones(n)
-            end=start+sc.promotetoarray(dur)/self.sim.dt
+            end = start + sc.promotetoarray(dur) / self.sim.dt
             self.append(p1=mother_inds, p2=unborn_inds, beta=beta, dur=dur, start=start, end=end)
             return n
 
 
 class PrenatalNet(MaternalNet):
-    """
-    Prenatal transmission network
-    """
+    """ Prenatal transmission network """
     def __init__(self, key_dict=None, prenatal=True, postnatal=False, **kwargs):
         super().__init__(key_dict=key_dict, prenatal=prenatal, postnatal=postnatal, **kwargs)
         return
 
 class PostnatalNet(MaternalNet):
-    """
-    Prenatal transmission network
-    """
+    """ Postnatal transmission network """
     def __init__(self, key_dict=None, prenatal=False, postnatal=True, **kwargs):
         super().__init__(key_dict=key_dict, prenatal=prenatal, postnatal=postnatal, **kwargs)
         return

--- a/starsim/network.py
+++ b/starsim/network.py
@@ -814,7 +814,7 @@ class MaternalNet(DynamicNetwork):
             if start is None: start = np.full_like(dur, fill_value=self.sim.ti)
             n = len(mother_inds)
             beta = np.ones(n)
-            end=start+dur/self.sim.dt
+            end=start+sc.promotetoarray(dur)/self.sim.dt
             self.append(p1=mother_inds, p2=unborn_inds, beta=beta, dur=dur, start=start, end=end)
             return n
 

--- a/starsim/network.py
+++ b/starsim/network.py
@@ -777,7 +777,7 @@ class EmbeddingNet(MFNet):
         return len(beta)
 
 
-class MaternalNet(Network):
+class MaternalNet(DynamicNetwork):
     """
     Base class for maternal transmission
     Use PrenatalNet and PostnatalNet to capture transmission in different phases
@@ -795,11 +795,16 @@ class MaternalNet(Network):
         Set beta to 0 for women who complete duration of transmission
         Keep connections for now, might want to consider removing
         """
-        dt = self.sim.dt
-        self.contacts.dur = self.contacts.dur - dt
-        inactive = self.contacts.dur <= 0
+        inactive = self.contacts.end <= self.sim.ti
         self.contacts.beta[inactive] = 0
         return
+
+    def end_pairs(self):
+        people = self.sim.people
+        active = (self.contacts.end > self.sim.ti) & people.alive[self.contacts.p1] & people.alive[self.contacts.p2]
+        for k in self.meta_keys():
+            self.contacts[k] = self.contacts[k][active]
+        return len(active)
 
     def add_pairs(self, mother_inds=None, unborn_inds=None, dur=None, start=None):
         """ Add connections between pregnant women and their as-yet-unborn babies """

--- a/starsim/parameters.py
+++ b/starsim/parameters.py
@@ -298,9 +298,10 @@ class SimPars(Pars):
     def validate_modules(self):
         """ Validate modules passed in pars"""
         
-        # Do special initializtaion on demographics
+        # Do special initializtaion on demographics and networks
         self.validate_demographics()
-        
+        self.validate_networks()
+
         # Get all modules into a consistent list format
         modmap = ss.module_map()
         for modkey in modmap.keys():
@@ -333,6 +334,24 @@ class SimPars(Pars):
         if self.use_aging is None:
             self.use_aging = True if self.demographics else False
         
+        return
+
+    def validate_networks(self):
+        """ Validate networks """
+        # Don't allow more than one prenatal or postnatal network
+        prenatal = [nw.prenatal for nw in self.networks]
+        postnatal = [nw.postnatal for nw in self.networks]
+        if sum(prenatal)>1:
+            prenatal_nets = np.array([nw.name for nw in self.networks])[prenatal]
+            errormsg = f'Starsim currently only supports one prenatal network; prenatal networks are: {prenatal_nets}'
+            raise ValueError(errormsg)
+        if sum(postnatal)>1:
+            postnatal_nets = np.array([nw.name for nw in self.networks])[postnatal]
+            errormsg = f'Starsim currently only supports one postnatal network; postnatal networks are: {postnatal_nets}'
+            raise ValueError(errormsg)
+            if not sum(prenatal):
+                errormsg = 'Starsim currently only supports adding a postnatal network if a prenatal network is present'
+                raise ValueError(errormsg)
         return
 
     def convert_modules(self):

--- a/starsim/parameters.py
+++ b/starsim/parameters.py
@@ -340,8 +340,8 @@ class SimPars(Pars):
     def validate_networks(self):
         """ Validate networks """
         # Don't allow more than one prenatal or postnatal network
-        prenatal_nets  = {k:nw for nw in self.networks.items() if nw.prenatal}
-        postnatal_nets = {k:nw for nw in self.networks.items() if nw.postnatal}
+        prenatal_nets  = {k:nw for k,nw in self.networks.items() if nw.prenatal}
+        postnatal_nets = {k:nw for k,nw in self.networks.items() if nw.postnatal}
         if len(prenatal_nets) > 1:
             errormsg = f'Starsim currently only supports one prenatal network; prenatal networks are: {prenatal_nets.keys()}'
             raise ValueError(errormsg)

--- a/starsim/parameters.py
+++ b/starsim/parameters.py
@@ -298,9 +298,8 @@ class SimPars(Pars):
     def validate_modules(self):
         """ Validate modules passed in pars"""
         
-        # Do special initializtaion on demographics and networks
+        # Do special initializtaion on demographics
         self.validate_demographics()
-        self.validate_networks()
 
         # Get all modules into a consistent list format
         modmap = ss.module_map()
@@ -314,6 +313,10 @@ class SimPars(Pars):
         # Convert from lists to ndicts
         for modkey,modclass in modmap.items():
             self[modkey] = ss.ndict(self[modkey], type=modclass)
+
+        # Check networks
+        self.validate_networks()
+
         return
     
     def validate_demographics(self):
@@ -339,14 +342,14 @@ class SimPars(Pars):
     def validate_networks(self):
         """ Validate networks """
         # Don't allow more than one prenatal or postnatal network
-        prenatal = [nw.prenatal for nw in self.networks]
-        postnatal = [nw.postnatal for nw in self.networks]
+        prenatal = [nw.prenatal for nw in self.networks.values()]
+        postnatal = [nw.postnatal for nw in self.networks.values()]
         if sum(prenatal)>1:
-            prenatal_nets = np.array([nw.name for nw in self.networks])[prenatal]
+            prenatal_nets = np.array([nw.name for nw in self.networks.values()])[prenatal]
             errormsg = f'Starsim currently only supports one prenatal network; prenatal networks are: {prenatal_nets}'
             raise ValueError(errormsg)
         if sum(postnatal)>1:
-            postnatal_nets = np.array([nw.name for nw in self.networks])[postnatal]
+            postnatal_nets = np.array([nw.name for nw in self.networks.values()])[postnatal]
             errormsg = f'Starsim currently only supports one postnatal network; postnatal networks are: {postnatal_nets}'
             raise ValueError(errormsg)
             if not sum(prenatal):

--- a/starsim/sim.py
+++ b/starsim/sim.py
@@ -69,7 +69,7 @@ class Sim(sc.prettyobj):
         # Initialize all the modules with the sim
         for mod in self.modules:
             mod.initialize(self)
-                
+
         # Initialize products # TODO: think about simplifying
         for mod in self.interventions:
             if hasattr(mod, 'product') and isinstance(mod.product, ss.Product):

--- a/starsim/version.py
+++ b/starsim/version.py
@@ -4,6 +4,6 @@ Version and license information.
 
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__ = '0.5.0'
-__versiondate__ = '2024-05-14'
+__version__ = '0.5.1'
+__versiondate__ = '2024-05-15'
 __license__ = f'Starsim {__version__} ({__versiondate__}) — © 2023-2024 by IDM'

--- a/tests/test_diseases.py
+++ b/tests/test_diseases.py
@@ -172,6 +172,16 @@ def test_multidisease():
     sim.run()
     return sim
 
+def test_mtct():
+    """ Test mother-to-child transmission routes """
+
+    ppl = ss.People(n_agents)
+    sis = ss.SIS(beta={'random':[0.005, 0.001], 'maternal':[0.1, 0]})
+    networks = [ss.RandomNet(), ss.MaternalNet()]
+    demographics = ss.Pregnancy(fertility_rate=20)
+    sim = ss.Sim(people=ppl, diseases=sis, networks=networks, demographics=demographics)
+    sim.run()
+    return sim
 
 if __name__ == '__main__':
     sc.options(interactive=do_plot)
@@ -181,3 +191,4 @@ if __name__ == '__main__':
     ncd   = test_ncd()
     gavi  = test_gavi()
     multi = test_multidisease()
+    mtct  = test_mtct()

--- a/tests/test_diseases.py
+++ b/tests/test_diseases.py
@@ -179,16 +179,16 @@ def test_mtct():
     sis = ss.SIS(beta={'random':[0.005, 0.001], 'prenatal':[0.1, 0], 'postnatal':[0.1, 0]})
     networks = [ss.RandomNet(), ss.PrenatalNet(), ss.PostnatalNet()]
     demographics = ss.Pregnancy(fertility_rate=20)
-    sim = ss.Sim(people=ppl, diseases=sis, networks=networks, demographics=demographics)
+    sim = ss.Sim(dt=1/12, people=ppl, diseases=sis, networks=networks, demographics=demographics)
     sim.run()
     return sim
 
 if __name__ == '__main__':
-    sc.options(interactive=do_plot)
-    sir   = test_sir()
-    s1,s2 = test_sir_epi()
-    sis   = test_sis()
-    ncd   = test_ncd()
-    gavi  = test_gavi()
-    multi = test_multidisease()
+    # sc.options(interactive=do_plot)
+    # sir   = test_sir()
+    # s1,s2 = test_sir_epi()
+    # sis   = test_sis()
+    # ncd   = test_ncd()
+    # gavi  = test_gavi()
+    # multi = test_multidisease()
     mtct  = test_mtct()

--- a/tests/test_diseases.py
+++ b/tests/test_diseases.py
@@ -176,8 +176,8 @@ def test_mtct():
     """ Test mother-to-child transmission routes """
 
     ppl = ss.People(n_agents)
-    sis = ss.SIS(beta={'random':[0.005, 0.001], 'maternal':[0.1, 0]})
-    networks = [ss.RandomNet(), ss.MaternalNet()]
+    sis = ss.SIS(beta={'random':[0.005, 0.001], 'prenatal':[0.1, 0], 'postnatal':[0.1, 0]})
+    networks = [ss.RandomNet(), ss.PrenatalNet(), ss.PostnatalNet()]
     demographics = ss.Pregnancy(fertility_rate=20)
     sim = ss.Sim(people=ppl, diseases=sis, networks=networks, demographics=demographics)
     sim.run()

--- a/tests/test_diseases.py
+++ b/tests/test_diseases.py
@@ -184,11 +184,11 @@ def test_mtct():
     return sim
 
 if __name__ == '__main__':
-    # sc.options(interactive=do_plot)
-    # sir   = test_sir()
-    # s1,s2 = test_sir_epi()
-    # sis   = test_sis()
-    # ncd   = test_ncd()
-    # gavi  = test_gavi()
-    # multi = test_multidisease()
+    sc.options(interactive=do_plot)
+    sir   = test_sir()
+    s1,s2 = test_sir_epi()
+    sis   = test_sis()
+    ncd   = test_ncd()
+    gavi  = test_gavi()
+    multi = test_multidisease()
     mtct  = test_mtct()

--- a/tests/test_syphilis.py
+++ b/tests/test_syphilis.py
@@ -28,12 +28,7 @@ def make_syph_sim(dt=1, n_agents=500):
     ppl = ss.People(n_agents, age_data=pd.read_csv(ss.root / 'tests/test_data/nigeria_age.csv'))
 
     # Marital
-    mf = ss.MFNet(
-        pars = dict(
-            duration = ss.lognorm_ex(mean=1/24, stdev=0.5),
-            acts = ss.lognorm_ex(mean=80, stdev=30),
-        )
-    )
+    mf = ss.MFNet(duration=1/24)
     maternal = ss.MaternalNet()
 
     sim_kwargs = dict(


### PR DESCRIPTION
### Description
Separates maternal transmission into prenatal and postnatal modules.

This is necessary because transmission probabilities vary. We could alternatively change the network betas, but this way allows us more flexibility to have disease-dependent differences - e.g. maternal transmission of syphilis only occurs during pregnancy, whereas for HIV it can also happen during breastfeeding.

### Checklist
- [x] Code commented & docstrings added
- [x] New tests were needed and have been added
- [x] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released