### PR TITLE
Pass Disease and Infection constructor arguments to parent

### DIFF
--- a/starsim/disease.py
+++ b/starsim/disease.py
@@ -15,8 +15,8 @@ __all__ = ['Disease', 'Infection', 'InfectionLog']
 class Disease(ss.Module):
     """ Base module class for diseases """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.results = ss.Results(self.name)
         self.log = InfectionLog()  # See below for definition
         return
@@ -137,8 +137,8 @@ class Infection(Disease):
     operate on to capture co-infection
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.add_states(
             ss.BoolArr('susceptible', default=True),
             ss.BoolArr('infected'),


### PR DESCRIPTION
### Description

Allows passing arguments to parent constructors e.g., to be able to set the `name` attribute

### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released