### PR TITLE
Fix Dist initialization

### DIFF
--- a/starsim/distributions.py
+++ b/starsim/distributions.py
@@ -92,10 +92,17 @@ class Dists(sc.prettyobj):
         if obj is None:
             errormsg = 'Must supply a container that contains one or more Dist objects, typically the sim'
             raise ValueError(errormsg)
-        self.dists = find_dists(obj)
+            
+        # Do not look for distributions in the people states, since they shadow the "real" states
+        skip = id(sim.people._states) if sim is not None else None
+        
+        # Find and initialize the distributions
+        self.dists = find_dists(obj, skip=skip)
         for trace,dist in self.dists.items():
             if not dist.initialized or force:
                 dist.initialize(trace=trace, seed=base_seed, sim=sim, force=force)
+        
+        # Confirm the seeds are unique
         self.check_seeds()
         self.initialized = True
         return self


### PR DESCRIPTION
### Description

Fixes the issue where some `Dist` objects were being found first in the `People._states` object, which gets keys assigned based on object ID, which are effectively random, making results non-reproducible. Closes #533 and #534.

### Checklist
- [x] Code commented & docstrings added
- [ ] New tests were needed and have been added†
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released

† I didn't add a test here; one could potentially loop through `sim.dists.dists` and test each RNG. But I think that test also wouldn't have caught this if implemented on a standard sim: if results are non-reproducible at that level, then `test_baselines.py` will fail.