### PR TITLE
Ensure returned Arr has np.array type

### DIFF
--- a/starsim/states.py
+++ b/starsim/states.py
@@ -254,7 +254,7 @@ class Arr(np.lib.mixins.NDArrayOperatorsMixin):
         new.__dict__ = self.__dict__.copy() # Copy pointers
         new.dtype = arr.dtype # Set to correct dtype
         new.name = name # In most cases, the asnew Arr has different values to the original Arr so the original name no longer makes sense
-        new.raw = np.empty_like(new.raw, dtype=new.dtype) # Copy values, breaking reference
+        new.raw = np.empty(new.raw.shape, dtype=new.dtype) # Copy values, breaking reference
         new.raw[new.auids] = arr
         return new
 


### PR DESCRIPTION
### Description

This addresses an unusual bug that arises when performing logical operations on a `uids` object, which is a subclass of `np.ndarray` - in that case, the use of `np.empty_like` causes the resulting `BoolArr` to have `uids` as the underlying type for the `raw` attribute rather than an `np.ndarray`. A subsequent logical operation will then use operators from `uids` rather than `np.ndarray`. This change uses `np.empty` rather than `np.empty_like` to ensure that the `raw` attribute is a bare `np.ndarray`

### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released