### PR TITLE
Initialize fertility rate explicitly

### DIFF
--- a/starsim/demographics.py
+++ b/starsim/demographics.py
@@ -306,7 +306,7 @@ class Pregnancy(Demographics):
         age = sim.people.age[uids]
 
         frd = self.fertility_rate_data
-        fertility_rate = np.empty(len(sim.people.uid.raw), dtype=ss_float_)
+        fertility_rate = np.zeros(len(sim.people.uid.raw), dtype=ss_float_)
 
         if sc.isnumber(frd):
             fertility_rate[uids] = self.fertility_rate_data


### PR DESCRIPTION
### Description

This prevents warnings/errors raised on certain platforms due to operating on uninitialized entries from `np.empty` - these entries are present to allow indexing the array by UID and aren't used for anything, so this doesn't affect any results, but are causing STIsim's tests to fail on Linux. Using `np.zeros` to initialize those entries resolves the issue

### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released