### PR TITLE
Improving pregnancy configuration and fixing test_randomness

### DIFF
--- a/starsim/demographics.py
+++ b/starsim/demographics.py
@@ -70,7 +70,7 @@ class Births(Demographics):
     def standardize_birth_data(self):
         """ Standardize/validate birth rates - handled in an external file due to shared functionality """
         birth_rate = ss.standardize_data(data=self.pars.birth_rate, metadata=self.metadata)
-        if isinstance(birth_rate, pd.Series) or isinstance(birth_rate, pd.DataFrame):
+        if isinstance(birth_rate, (pd.Series, pd.DataFrame)):
             return birth_rate.xs(0,level='age')
         return birth_rate
 
@@ -95,7 +95,7 @@ class Births(Demographics):
         sim = self.sim
         p = self.pars
 
-        if isinstance(p.birth_rate, pd.Series) or isinstance(p.birth_rate, pd.DataFrame):
+        if isinstance(p.birth_rate, (pd.Series, pd.DataFrame)):
             available_years = p.birth_rate.index
             year_ind = sc.findnearest(available_years, sim.year)
             nearest_year = available_years[year_ind]
@@ -184,7 +184,7 @@ class Deaths(Demographics):
     def standardize_death_data(self):
         """ Standardize/validate death rates - handled in an external file due to shared functionality """
         death_rate = ss.standardize_data(data=self.pars.death_rate, metadata=self.metadata)
-        if isinstance(death_rate, pd.Series) or isinstance(death_rate, pd.DataFrame):
+        if isinstance(death_rate, (pd.Series, pd.DataFrame)):
             death_rate = death_rate.unstack(level='age')
             assert not death_rate.isna().any(axis=None) # For efficiency, we assume that the age bins are the same for all years in the input dataset
         return death_rate
@@ -353,7 +353,7 @@ class Pregnancy(Demographics):
         Standardize/validate fertility rates
         """
         fertility_rate = ss.standardize_data(data=self.pars.fertility_rate, metadata=self.metadata)
-        if isinstance(fertility_rate, pd.Series) or isinstance(fertility_rate, pd.DataFrame):
+        if isinstance(fertility_rate, (pd.Series, pd.DataFrame)):
             fertility_rate = fertility_rate.unstack()
             assert not fertility_rate.isna().any(axis=None) # For efficiency, we assume that the age bins are the same for all years in the input dataset
         return fertility_rate
@@ -364,8 +364,6 @@ class Pregnancy(Demographics):
         # Process data, which may be provided as a number, dict, dataframe, or series
         # If it's a number it's left as-is; otherwise it's converted to a dataframe
         self.fertility_rate_data = self.standardize_fertility_data()
-        #self.pars.p_fertility = ss.bernoulli(p=self.make_fertility_prob_fn)
-        #self.pars.p_fertility.pars['p'] = self.make_fertility_prob_fn
         self.pars.p_fertility.set(p=self.make_fertility_prob_fn)
 
         low = sim.pars.n_agents + 1
@@ -420,7 +418,7 @@ class Pregnancy(Demographics):
 
                 # Validation
                 if not np.array_equal(new_mother_uids, deliveries.uids):
-                    errormsg = f'IDs of new mothers do not match IDs of new deliveries.'
+                    errormsg = 'IDs of new mothers do not match IDs of new deliveries'
                     raise ValueError(errormsg)
 
                 # Create durations and start dates, and add connections

--- a/starsim/demographics.py
+++ b/starsim/demographics.py
@@ -257,9 +257,9 @@ class Pregnancy(Demographics):
     def __init__(self, pars=None, metadata=None, **kwargs):
         super().__init__()
         self.default_pars(
-            dur_pregnancy = 0.75,   # Duration for pre-natal transmission
-            dur_postpartum = ss.lognorm_ex(0.5, 0.5),   # Duration for post-natal transmission (e.g. via breastfeeding)
-            fertility_rate = 0,     # See make_fertility_prob_function
+            dur_pregnancy = 0.75, # Duration for pre-natal transmission
+            dur_postpartum = ss.lognorm_ex(0.5, 0.5), # Duration for post-natal transmission (e.g. via breastfeeding)
+            fertility_rate = 0, # Can be a number of Pandas DataFrame
             rel_fertility = 1,
             maternal_death_prob = ss.bernoulli(0),
             sex_ratio = ss.bernoulli(0.5), # Ratio of babies born female
@@ -268,6 +268,8 @@ class Pregnancy(Demographics):
             units = 1e-3, # Assumes fertility rates are per 1000. If using percentages, switch this to 1
         )
         self.update_pars(pars, **kwargs)
+
+        self.pars.p_fertility = ss.bernoulli(p=0) # Placeholder, see make_fertility_prob_fn
         
         # Other, e.g. postpartum, on contraception...
         self.add_states(
@@ -288,11 +290,6 @@ class Pregnancy(Demographics):
             metadata,
         )
         self.choose_slots = None # Distribution for choosing slots; set in self.initialize()
-
-        # Process data, which may be provided as a number, dict, dataframe, or series
-        # If it's a number it's left as-is; otherwise it's converted to a dataframe
-        self.fertility_rate_data = self.standardize_fertility_data()
-        self.pars.fertility_rate = ss.bernoulli(self.make_fertility_prob_fn)
 
         # For results tracking
         self.n_pregnancies = 0
@@ -357,6 +354,14 @@ class Pregnancy(Demographics):
 
     def init_pre(self, sim):
         super().init_pre(sim)
+
+        # Process data, which may be provided as a number, dict, dataframe, or series
+        # If it's a number it's left as-is; otherwise it's converted to a dataframe
+        self.fertility_rate_data = self.standardize_fertility_data()
+        #self.pars.p_fertility = ss.bernoulli(p=self.make_fertility_prob_fn)
+        #self.pars.p_fertility.pars['p'] = self.make_fertility_prob_fn
+        self.pars.p_fertility.set(p=self.make_fertility_prob_fn)
+
         low = sim.pars.n_agents + 1
         high = int(sim.pars.slot_scale*sim.pars.n_agents)
         self.choose_slots = ss.randint(low=low, high=high, sim=sim, module=self)
@@ -435,7 +440,7 @@ class Pregnancy(Demographics):
         # People eligible to become pregnant. We don't remove pregnant people here, these
         # are instead handled in the fertility_dist logic as the rates need to be adjusted
         eligible_uids = self.sim.people.female.uids
-        conceive_uids = self.pars.fertility_rate.filter(eligible_uids)
+        conceive_uids = self.pars.p_fertility.filter(eligible_uids)
 
         # Validation
         if np.any(self.pregnant[conceive_uids]):

--- a/starsim/demographics.py
+++ b/starsim/demographics.py
@@ -178,8 +178,9 @@ class Deaths(Demographics):
     def standardize_death_data(self):
         """ Standardize/validate death rates - handled in an external file due to shared functionality """
         death_rate = ss.standardize_data(data=self.pars.death_rate, metadata=self.metadata)
-        death_rate = death_rate.unstack(level='age')
-        assert not death_rate.isna().any(axis=None) # For efficiency, we assume that the age bins are the same for all years in the input dataset
+        if isinstance(death_rate, pd.Series) or isinstance(death_rate, pd.DataFrame):
+            death_rate = death_rate.unstack(level='age')
+            assert not death_rate.isna().any(axis=None) # For efficiency, we assume that the age bins are the same for all years in the input dataset
         return death_rate
 
     @staticmethod # Needs to be static since called externally, although it sure looks like a class method!
@@ -346,10 +347,9 @@ class Pregnancy(Demographics):
         Standardize/validate fertility rates
         """
         fertility_rate = ss.standardize_data(data=self.pars.fertility_rate, metadata=self.metadata)
-        fertility_rate = fertility_rate.unstack()
-        max_age = fertility_rate.columns.max()
-        fertility_rate[max_age+1] = 0
-        assert not fertility_rate.isna().any(axis=None) # For efficiency, we assume that the age bins are the same for all years in the input dataset
+        if isinstance(fertility_rate, pd.Series) or isinstance(fertility_rate, pd.DataFrame):
+            fertility_rate = fertility_rate.unstack()
+            assert not fertility_rate.isna().any(axis=None) # For efficiency, we assume that the age bins are the same for all years in the input dataset
         return fertility_rate
 
     def init_pre(self, sim):

--- a/starsim/utils.py
+++ b/starsim/utils.py
@@ -267,8 +267,7 @@ def standardize_data(data=None, metadata=None, min_year=1800, out_of_range=0, de
     if isinstance(data, ss.Dist):
         return data
     elif sc.isnumber(data):
-        index = pd.MultiIndex.from_arrays([[default_year, default_year], [-np.inf, 0]], names=['year','age'])
-        return pd.Series(index=index, data=[out_of_range, data])
+        return data
 
     # Convert series and dataframe inputs into dicts
     if isinstance(data, pd.Series) or isinstance(data, pd.DataFrame):

--- a/tests/test_randomness.py
+++ b/tests/test_randomness.py
@@ -291,8 +291,8 @@ def test_combine_rands(do_plot=False):
     atol = 1e-3
     target = 0.5
     np.random.seed(2)
-    a = np.random.randint(low=np.iinfo(np.int64).min, high=np.iinfo(np.int64).max, dtype=np.int64, size=n)
-    b = np.random.randint(low=np.iinfo(np.int64).min, high=np.iinfo(np.int64).max, dtype=np.int64, size=n)
+    a = np.random.randint(np.iinfo(np.int64).max, size=n)
+    b = np.random.randint(np.iinfo(np.int64).max, size=n)
     c = ss.combine_rands(a, b)
     if do_plot:
         pl.figure()

--- a/tests/test_randomness.py
+++ b/tests/test_randomness.py
@@ -291,8 +291,8 @@ def test_combine_rands(do_plot=False):
     atol = 1e-3
     target = 0.5
     np.random.seed(2)
-    a = np.random.randint(low=0, high=np.iinfo(np.uint64).max, dtype=np.uint64, size=n)
-    b = np.random.randint(low=0, high=np.iinfo(np.uint64).max, dtype=np.uint64, size=n)
+    a = np.random.randint(low=np.iinfo(np.int64).min, high=np.iinfo(np.int64).max, dtype=np.int64, size=n)
+    b = np.random.randint(low=np.iinfo(np.int64).min, high=np.iinfo(np.int64).max, dtype=np.int64, size=n)
     c = ss.combine_rands(a, b)
     if do_plot:
         pl.figure()


### PR DESCRIPTION
Fixing demographics so that users can override the fertility rate parameter even if using a subclass. Now `self.pars.p_fertility` in `init_pre` rather than doing everything in `__init__`.

Also changing `uint64` to signed `int64` in test_randomness.

### Description


### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released