### PR TITLE
Logging off by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ What's new
 All notable changes to the codebase are documented in this file. Changes that may result in differences in model output, or are required in order to run an old parameter set with the current version, are flagged with the term "Regression information".
 
 
+Version 0.5.8 (2024-06-30)
+--------------------------
+- Revert to making infection logging disabled by default. However, the infection log will now always be created so disease subclasses can override logging behaviour where required (e.g., to capture additional metadata)
+
+**Backwards-compatibility notes**
+
+- Logging has been moved from an argument to ``Disease`` to ``pars``. Existing code such as ``Disease(log=True)`` should be changed to ``Disease(pars={'log':True})``. The 'log' option can be added to the pars passed to any subclass e.g., ``ss.HIV(pars={...,log=True})``.
+
 Version 0.5.7 (2024-06-27)
 --------------------------
 - Implemented a new ``ss.combine_rands()`` function based on a bitwise-XOR, since the previous modulo-based approach could introduce correlations between pairs of agents.

--- a/starsim/disease.py
+++ b/starsim/disease.py
@@ -17,10 +17,14 @@ __all__ = ['Disease', 'Infection', 'InfectionLog']
 class Disease(ss.Module):
     """ Base module class for diseases """
 
-    def __init__(self, log=True, *args, **kwargs):
+    def __init__(self, pars=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.default_pars(
+            log = False,
+        )
+        self.update_pars(pars, **kwargs)
         self.results = ss.Results(self.name)
-        self.log = InfectionLog() if log else None  # See below for definition
+        self.log = InfectionLog()
         return
 
     @property
@@ -97,10 +101,11 @@ class Disease(ss.Module):
 
         This function assigns state values upon infection or acquisition of
         the disease. It would normally be called somewhere towards the end of
-        `Disease.make_new_cases()`. Infections will automatically be added to
-        the log as part of this operation.
+        `Disease.make_new_cases()`. Infections will optionally be added to
+        the log as part of this operation if logging is enabled (in the
+        `Disease` parameters)
 
-        The from_uids are relevant for infectious diseases, but would be left
+        The `from_uids` are relevant for infectious diseases, but would be left
         as `None` for NCDs.
 
         Args:
@@ -108,7 +113,7 @@ class Disease(ss.Module):
             uids (array): UIDs for agents to assign disease progoses to
             from_uids (array): Optionally specify the infecting agent
         """
-        if self.log is not None:
+        if self.pars.log:
             sim = self.sim
             if source_uids is None:
                 for target in uids:

--- a/starsim/modules.py
+++ b/starsim/modules.py
@@ -62,7 +62,7 @@ class Module(sc.quickobj):
         self.requires = sc.mergelists(requires)
         return
     
-    def default_pars(self, inherit=False, **kwargs):
+    def default_pars(self, inherit=True, **kwargs):
         """ Create or merge Pars objects """
         if inherit: # Merge with existing
             self.pars.update(**kwargs, create=True)

--- a/starsim/version.py
+++ b/starsim/version.py
@@ -4,6 +4,6 @@ Version and license information.
 
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__ = '0.5.7'
-__versiondate__ = '2024-06-27'
+__version__ = '0.5.8'
+__versiondate__ = '2024-06-30'
 __license__ = f'Starsim {__version__} ({__versiondate__}) — © 2023-2024 by IDM'

--- a/tests/test_diseases.py
+++ b/tests/test_diseases.py
@@ -118,7 +118,7 @@ def test_sis(do_plot=do_plot):
 
 def test_ncd():
     ppl = ss.People(n_agents)
-    ncd = ss.NCD()
+    ncd = ss.NCD(pars={'log':True})
     sim = ss.Sim(people=ppl, diseases=ncd, copy_inputs=False) # Since using ncd directly below
     sim.run()
 


### PR DESCRIPTION
### Description

This PR changes `log` from an argument of `Disease` to being part of the pars, so that it can be passed more easily through inheritance and handled alongside any other module settings. The `InfectionLog` is still created so that it can be used by custom code even if standard logging is not enabled (this is what STIsim does) but entries are only added to it by Starsim if `log=True`

### Checklist
- [x] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [x] A new version number was needed & changelog has been updated
- [x] A new PyPI version needs to be released