### PR TITLE
Update dtype of randint distribution

### DIFF
--- a/starsim/distributions.py
+++ b/starsim/distributions.py
@@ -719,7 +719,7 @@ class poisson(Dist):
 
 class randint(Dist):
     """ Randint distribution, integer values on interval [low, high) using numpy.random.Generator.integers """
-    def __init__(self, low=0, high=np.iinfo(ss.dtypes.int).max, dtype=int, **kwargs):
+    def __init__(self, low=0, high=np.iinfo(ss.dtypes.int).max, dtype=ss.dtypes.int, **kwargs):
         if ss.options._centralized:
             # randint because we're accessing via numpy.random
             super().__init__(distname='randint', low=low, high=high, dtype=dtype, **kwargs)


### PR DESCRIPTION
### Description
This PR updates the `dtype` of the `randint`-Distribution from `int` to `ss.dtypes.int (= numpy.int64)`.
Main returns an error when running on my local mashine that `high` is out of bounds, because it is assumed to be of type `int32`.

### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released