### PR TITLE
Inplace fix

### DIFF
--- a/starsim/states.py
+++ b/starsim/states.py
@@ -171,7 +171,8 @@ class Arr(np.lib.mixins.NDArrayOperatorsMixin):
         try:
             return self.people.auids
         except:
-            ss.warn('Trying to access non-initialized States object')
+            if not self.initialized:
+                ss.warn('Trying to access non-initialized States object')
             return uids(np.arange(len(self.raw)))
     
     def count(self):

--- a/starsim/states.py
+++ b/starsim/states.py
@@ -120,7 +120,7 @@ class Arr(np.lib.mixins.NDArrayOperatorsMixin):
         the raw array (``raw``) or the active agents (``values``), and to convert
         the key to array indices if needed.
         """
-        if isinstance(key, (uids, int)):
+        if isinstance(key, (uids, int, ss_int)):
             return key
         elif isinstance(key, (BoolArr, IndexArr)):
             return key.uids

--- a/starsim/states.py
+++ b/starsim/states.py
@@ -219,8 +219,6 @@ class Arr(np.lib.mixins.NDArrayOperatorsMixin):
             new_uids: Numpy array of UIDs for the new agents being added
             new_vals: If provided, assign these state values to the new UIDs
         """
-        if new_uids is None and new_vals is not None: # Used as a shortcut to avoid needing to supply twice
-            new_uids = new_vals
         orig_len = self.len_used
         n_new = len(new_uids)
         self.len_used += n_new  # Increase the count of the number of agents by `n` (the requested number of new agents)
@@ -348,6 +346,8 @@ class IndexArr(Arr):
     
     def grow(self, new_uids=None, new_vals=None):
         """ Change the size of the array """
+        if new_uids is None and new_vals is not None: # Used as a shortcut to avoid needing to supply twice
+            new_uids = new_vals
         super().grow(new_uids=new_uids, new_vals=new_vals)
         self.raw = uids(self.raw)
         return

--- a/starsim/states.py
+++ b/starsim/states.py
@@ -72,7 +72,7 @@ class Arr(np.lib.mixins.NDArrayOperatorsMixin):
         skip_init (bool): Whether to skip initialization with the People object (used for uid and slot states)
         people (ss.People): Optionally specify an initialized People object, used to construct temporary Arr instances
     """
-    def __init__(self, name, dtype=None, default=None, nan=None, label=None, coerce=True, skip_init=False, people=None):
+    def __init__(self, name=None, dtype=None, default=None, nan=None, label=None, coerce=True, skip_init=False, people=None):
         if coerce:
             dtype = check_dtype(dtype, default)
         
@@ -279,7 +279,7 @@ class Arr(np.lib.mixins.NDArrayOperatorsMixin):
 
 class FloatArr(Arr):
     """ Subclass of Arr with defaults for floats """
-    def __init__(self, name, nan=np.nan, **kwargs):
+    def __init__(self, name=None, nan=np.nan, **kwargs):
         super().__init__(name=name, dtype=ss_float, nan=nan, coerce=False, **kwargs)
         return
 
@@ -303,7 +303,7 @@ class FloatArr(Arr):
 
 class BoolArr(Arr):
     """ Subclass of Arr with defaults for booleans """
-    def __init__(self, name, nan=False, **kwargs): # No good NaN equivalent for bool arrays
+    def __init__(self, name=None, nan=False, **kwargs): # No good NaN equivalent for bool arrays
         super().__init__(name=name, dtype=ss_bool, nan=nan, coerce=False, **kwargs)
         return
     
@@ -335,7 +335,7 @@ class BoolArr(Arr):
     
 class IndexArr(Arr):
     """ A special class of IndexArr used for UIDs and RNG IDs """
-    def __init__(self, name, label=None):
+    def __init__(self, name=None, label=None):
         super().__init__(name=name, dtype=ss_int, default=None, nan=-1, label=label, coerce=False, skip_init=True)
         self.raw = uids(self.raw)
         return


### PR DESCRIPTION
### Description

Fixes #502 - importantly, when testing this, it's necessary to check for in-place operations working on `Arr` instances where some of the agents are dead, to make sure that the result of the in-place operation is written back to the correct indices in `Arr.raw`. Accordingly, this is the test I've been using:

```python
import starsim as ss
import numpy as np
import sciris as sc

uids = ss.IndexArr()
uids.grow(np.arange(8))
people = sc.objdict(uid=uids, auids=np.array([1,3,5,7]))
x = ss.FloatArr(people=people)

# Test inplace operations
x[:] = 1
print(x)
print(x.raw)
x += 1
print(x)
print(x.raw)
x[ss.uids([1,3])] += 1
print(x)
print(x.raw)

# Test other operations are OK
print(x + 1)
print(x + [10,10,10,10])
print(x[ss.uids([1,3])] + [5,5])
print(x+x)
```

### Checklist
- [x] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released