### PR TITLE
Fixing two bugs that have appeared in CRN simulations

### DIFF
--- a/starsim/distributions.py
+++ b/starsim/distributions.py
@@ -967,7 +967,7 @@ class histogram(Dist):
             bins = np.append(bins, bins[-1]+delta)
         vsum = values.sum()
         if vsum != 1.0:
-            values /= vsum
+            values = values / vsum
         dist = sps.rv_histogram((values, bins), density=density) # Create the SciPy distribution
         super().__init__(dist=dist, distname='histogram', **kwargs)
         self.dynamic_pars = False # Set to false since array arguments don't imply dynamic pars here

--- a/starsim/run.py
+++ b/starsim/run.py
@@ -331,7 +331,9 @@ def single_run(sim, ind=0, reseed=True, keep_people=False, run_args=None, sim_ar
         if key in sim.pars.keys():
             if verbose >= 1:
                 print(f'Setting key {key} from {sim[key]} to {val}')
-                sim[key] = val
+            sim.pars[key] = val
+            if key == 'rand_seed':
+                ss.set_seed()
         else:
             raise sc.KeyNotFoundError(f'Could not set key {key}: not a valid parameter name')
 


### PR DESCRIPTION
1. Distribution normalization data type conversion
2. Setting simulation parameters was not working in `run_single`?! Additional update for setting the random seed.

### Description


### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released