### PR TITLE
scrub BasePeople vestigial comments

### DIFF
--- a/starsim/people.py
+++ b/starsim/people.py
@@ -20,9 +20,8 @@ class People(sc.prettyobj):
     will get passed instead since it will be needed before the People object is
     initialized.
 
-    Note that this class handles the mechanics of updating the actual people, while
-    ``ss.BasePeople`` takes care of housekeeping (saving, loading, exporting, etc.).
-    Please see the BasePeople class for additional methods.
+    Note that this class handles the mechanics of updating the actual people, 
+    as well as the additional housekeeping methods (saving, loading, exporting, etc.).
 
     Args:
         pars (dict): the sim parameters, e.g. sim.pars -- alternatively, if a number, interpreted as n_agents

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -19,7 +19,7 @@ def test_people():
     sc.heading('Testing people object')
 
     # Base people contains only the states defined in base.base_states
-    ppl = ss.People(small)  # BasePeople
+    ppl = ss.People(small)
     del ppl
 
     # Possible to initialize people with extra states, e.g. a geolocation


### PR DESCRIPTION
Nominally addresses issue #616 on vestigial BasePeople comments after merge with People for 0.5.0 release.

Please check that the wording in people.py docstring of People is an accurate representation, or if we prefer just to drop that whole second paragraph.