### PR TITLE
Make jump robust

### DIFF
--- a/starsim/diseases/syphilis.py
+++ b/starsim/diseases/syphilis.py
@@ -210,10 +210,6 @@ class Syphilis(ss.Infection):
             self.set_secondary_prognoses(secondary_from_primary)
             self.rel_trans[secondary_from_primary] = self.pars.rel_trans['secondary']
 
-        # Hack to reset the MultiRNGs in set_secondary_prognoses so that they can be called again in this timestep. TODO: Refactor
-        self.pars.p_latent_temp.jump(ti+1)
-        self.pars.dur_secondary.jump(ti+1)
-
         # Secondary reactivation from latent
         secondary_from_latent = (self.latent_temp & (self.ti_secondary <= ti)).uids
         if len(secondary_from_latent) > 0:

--- a/starsim/distributions.py
+++ b/starsim/distributions.py
@@ -207,7 +207,7 @@ class Dist:
         self._slots = None # Internal variable to track currently-in-use slots
         
         # History and random state
-        self.dt_jump_size = 1000 # How much to advance the RNG for each timestep
+        self.dt_jump_size = 1000 # How much to advance the RNG for each timestep (must be larger than the number times dist is called per timestep)
         self.rng = None # The actual RNG generator for generating random numbers
         self.trace = None # The path of this object within the parent
         self.ind = 0 # The index of the RNG (usually updated on each timestep)

--- a/starsim/distributions.py
+++ b/starsim/distributions.py
@@ -357,11 +357,11 @@ class Dist:
         Automatically jump on the next value of dt
         
         Args:
-            ti (int): if specified, jump to this timestep (default: current sim timestep)
+            ti (int): if specified, jump to this timestep (default: current sim timestep plus one)
         """
         if ti is None:
-            ti = self.sim.ti
-        to = self.dt_jump_size*(self.sim.ti+1)
+            ti = self.sim.ti + 1
+        to = self.dt_jump_size*ti
         return self.jump(to=to, force=force)
     
     def init(self, trace=None, seed=None, module=None, sim=None, slots=None, force=False):

--- a/starsim/products.py
+++ b/starsim/products.py
@@ -104,26 +104,20 @@ class Tx(Product):
         tx_successful = []  # Initialize list of successfully treated individuals
 
         for disease_name in self.diseases:
-
             disease = self.sim.diseases[disease_name]
 
             for state in self.health_states:
-
                 pre_tx_state = getattr(disease, state)
                 true_uids = pre_tx_state.uids # People in this state
                 these_uids = true_uids.intersect(uids)
 
                 if len(these_uids):
-
                     df_filter = (self.df.state == state) & (self.df.disease == disease_name)  # Filter by state
                     thisdf = self.df[df_filter]  # apply filter to get the results for this state & genotype
 
                     # Determine whether treatment is successful
                     self.efficacy_dist.set(p=thisdf.efficacy.values[0])
-
-                    # HACK to reset the efficacy_dist as it is called multiple times per timestep. TODO: Refactor
-                    self.efficacy_dist.jump(self.sim.ti+1)
-                    eff_treat_inds = self.efficacy_dist.filter(these_uids)
+                    eff_treat_inds = self.efficacy_dist.filter(these_uids) # TODO: think if there's a way of not calling this inside a loop like this
 
                     post_tx_state_name = thisdf.post_state.values[0]
                     post_tx_state = getattr(disease, post_tx_state_name)

--- a/tests/test_randomness.py
+++ b/tests/test_randomness.py
@@ -152,7 +152,7 @@ class OneMore(ss.Intervention):
             # Reset the random states
             p = sir.pars
             for dist in [p.dur_inf, p.p_death]:
-                dist.jump_dt() # Already has correct dt value
+                dist.jump_dt(force=True) # Already has correct dt value, but we need to force going back in time
 
         return
 


### PR DESCRIPTION
Makes the changes to `jump` discussed on the call -- which already caught two bugs in the code (both of which were due to ancient holdovers from the `MultiRNG` days).

If these changes look good, I'll backport `jump_dt()` and the updated `jump()` to Starsim v1.0.