### PR TITLE
Tiny fixes in test calib and calibration

### DIFF
--- a/starsim/calibration.py
+++ b/starsim/calibration.py
@@ -88,6 +88,9 @@ class Calibration(sc.prettyobj):
         sim = sc.dcp(self.sim)
         if label: sim.label = label
 
+        if 'rand_seed' in calib_pars:
+            sim.pars['rand_seed'] = calib_pars.pop('rand_seed')
+
         sim = self.build_fn(sim, calib_pars=calib_pars, **self.build_kw)
 
         # Run the sim
@@ -106,7 +109,7 @@ class Calibration(sc.prettyobj):
     @staticmethod
     def translate_pars(sim=None, calib_pars=None):
         """ Take the nested dict of calibration pars and modify the sim """
-
+        # TODO: remove if handleded in run_sim()?
         if 'rand_seed' in calib_pars:
             sim.pars['rand_seed'] = calib_pars.pop('rand_seed')
 

--- a/starsim/calibration.py
+++ b/starsim/calibration.py
@@ -466,7 +466,7 @@ class CalibComponent(sc.prettyobj):
                 errormsg = f'The nll_fn (negative log-likelihood function) argument must be "beta" or "gamma", not {conform}.'
                 raise ValueError(errormsg)
         else:
-            if not callable(conform):
+            if not callable(nll_fn):
                 msg = f'The nll_fn (negative log-likelihood function) argument must be a string or a callable function, not {type(nll_fn)}.'
                 raise Exception(msg)
             self.nll_fn = nll_fn

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -7,7 +7,7 @@ import sciris as sc
 import starsim as ss
 import pandas as pd
 
-debug = False # If true, will run in serial
+debug = False  # If true, will run in serial
 do_plot = 1
 do_save = 0
 n_agents = 2e3
@@ -66,8 +66,8 @@ def test_calibration(do_plot=False):
 
     # Define the calibration parameters
     calib_pars = dict(
-        beta = dict(low=0.01, high=0.30, guess=0.15, suggest_type='suggest_float', log=True), # Log scale and no "path", will be handled by build_sim (ablve)
-        init_prev = dict(low=0.01, high=0.05, guess=0.15, path=('diseases', 'hiv', 'init_prev')), # Default type is suggest_float, no need to re-specify
+        beta = dict(low=0.01, high=0.30, guess=0.15, suggest_type='suggest_float', log=True, path=('diseases', 'sir', 'beta')), # Log scale and no "path", will be handled by build_sim (ablve)
+        init_prev = dict(low=0.01, high=0.05, guess=0.15, path=('diseases', 'sir', 'init_prev')), # Default type is suggest_float, no need to re-specify
         n_contacts = dict(low=2, high=10, guess=3, suggest_type='suggest_int', path=('networks', 'randomnet', 'n_contacts')), # Suggest int just for demo
     )
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -43,11 +43,11 @@ def build_sim(sim, calib_pars, **kwargs):
 
     # Capture any parameters that need special handling here
     for k, pars in calib_pars.items():
+        v = pars['value']
         if k == 'rand_seed':
             sim.pars.rand_seed = v
             continue
 
-        v = pars['value']
         if k == 'beta':
             sir.pars.beta = ss.beta(v)
         elif k == 'init_prev':


### PR DESCRIPTION
### Description
- In `test_calibration.py`:
    - Super tiny fix: moves line that could  have resulted in an error or a mistake for 'rand_seed', depending on the order of keys in calib parameters.
    - Fix path to parameters in `calib_pars`
- In `calibration.py`: 
    - Remove `rand_seed` from `calib_pars` before self.build_fn is called. `rand_seed`'s value is an int not a dict like for the rest of the calib parameters
 
![image](https://github.com/user-attachments/assets/2f3211a3-93eb-437f-8fdb-092fbde7b0f8)

