### PR TITLE
Small bug in samples class when retrieving items 

### DIFF
--- a/starsim/samples.py
+++ b/starsim/samples.py
@@ -387,7 +387,7 @@ class Samples:
 
         if item not in self._cache:
             with self.zipfile.open(self._seedfile(item)) as f:
-                self._cache[item] = sc.dataframe.read_csv(f, index_col="t")
+                self._cache[item] = sc.dataframe.read_csv(f, index_col="timevec")
 
         return self._cache[item].copy()
 

--- a/starsim/samples.py
+++ b/starsim/samples.py
@@ -282,7 +282,7 @@ class Samples:
         return f'seed_{seed}.csv'
 
     @classmethod
-    def new(cls, folder, outputs, identifiers=None, fname=None):
+    def new(cls, folder, outputs, identifiers=None, fname=None, verbose=True):
         """
         Args:
             folder: The folder name
@@ -322,7 +322,7 @@ class Samples:
         folder.mkdir(parents=True, exist_ok=True)
 
         # Save the zip file
-        sc.savezip(folder/fname, data=zipdata, tobytes=False)
+        sc.savezip(folder/fname, data=zipdata, tobytes=False, verbose=verbose)
 
         return cls(folder/fname, memory_buffer=False)
 

--- a/starsim/samples.py
+++ b/starsim/samples.py
@@ -89,6 +89,7 @@ class Dataset:
         else:
             return ds[0]
 
+# File names used in the zip file
 identifiers_file = 'identifiers.txt'
 summary_file = 'summary.csv'
 
@@ -177,7 +178,11 @@ class Samples:
             return zipfile.ZipFile(self._fname, mode="r")
 
     def __repr__(self):
-        return f"<Samples {'-'.join(str(x) for x in self.id.values())}, {len(self)} seeds>"
+        _id = self.id.values()
+        if _id:
+            return f"<Samples {'-'.join(str(x) for x in _id)}, {len(self)} seeds>"
+        else:
+            return f"<Samples (no identifier), {len(self)} seeds>"
 
     @property
     def index(self):
@@ -202,10 +207,12 @@ class Samples:
         e.g. the identifier could contain the starting level of restrictions. The dimensionality
         will vary depending on the analysis, hence it returns a tuple of arbitrary length. It would
         just be expected that all results being analyzed at the same time would have the same set of
-        identifiers. The first two index levels are always 'beta' and 'seed', therefore these are
-        dropped from the ID.
+        identifiers. The first index level is always 'seed', therefore it will dropped from the ID.
         """
-        return tuple(self.summary.iloc[0].name[1:])
+        if len(self.summary.index.names) == 1:
+            return tuple()
+        else:
+            return tuple(self.summary.iloc[0].name[1:])
 
     @property
     def id(self):
@@ -214,9 +221,9 @@ class Samples:
 
         For example:
 
-        >>> result.id
+        >>> result.identifier
         (2.0, 'Gradually escalate restrictions', 0.16, 0.5, '95_70', 1)
-        >>>  result.identifier
+        >>>  result.id
         {'beta_multiplier': 2.0,
          'strategy': 'Gradually escalate restrictions',
          'symp_test': 0.16,
@@ -275,12 +282,13 @@ class Samples:
         return f'seed_{seed}.csv'
 
     @classmethod
-    def new(cls, folder, outputs, identifiers, fname=None):
+    def new(cls, folder, outputs, identifiers=None, fname=None):
         """
         Args:
             folder: The folder name
             outputs: A list of tuples (df:pd.DataFrame, summary_row:dict) where the summary row as an entry 'seed' for the seed
-            identifiers: A list of columns to use as identifiers. These should appear in the summary dataframe and should have the same value for all samples.
+            identifiers: A list of columns to use as identifiers. These should appear in the summary dataframe and should have the
+                         same value for all samples. This is useful when generating multiple sets of results e.g., for scenarios (optional)
         """
         zipdata = {} # Store all the data to be written as files inside the zipfile
         summary_rows = []

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -55,8 +55,17 @@ def test_verbose():
     s = ss.Samples.new(resultsdir, outputs, identifiers=["p_death"], verbose=False)
     return s
 
+def test_seed_result():
+    outputs = get_outputs(0.2)
+    resultsdir = tempdir/'samples_results'
+    resultsdir.mkdir(exist_ok=True)
+    s = ss.Samples.new(resultsdir, outputs, identifiers=["p_death"], verbose=False)
+    return s[0]
+
+
 if __name__ == '__main__':
     samples = test_samples()
     samples = test_samples_no_identifier()
     samples = test_verbose()
+    seed_result = test_seed_result()
     results = test_dataset()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -25,6 +25,13 @@ def get_outputs(p_death):
         outputs.append((df, summary))
     return outputs
 
+def test_samples_no_identifier():
+    outputs = get_outputs(0.2)
+    resultsdir = tempdir/'samples_results'
+    resultsdir.mkdir(exist_ok=True)
+    s = ss.Samples.new(resultsdir, outputs)
+    return s
+
 def test_samples():
     outputs = get_outputs(0.2)
     resultsdir = tempdir/'samples_results'
@@ -41,7 +48,7 @@ def test_dataset():
     results = ss.Dataset(resultsdir)
     return results
 
-
 if __name__ == '__main__':
     samples = test_samples()
+    samples = test_samples_no_identifier()
     results = test_dataset()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -48,7 +48,15 @@ def test_dataset():
     results = ss.Dataset(resultsdir)
     return results
 
+def test_verbose():
+    outputs = get_outputs(0.2)
+    resultsdir = tempdir/'samples_results'
+    resultsdir.mkdir(exist_ok=True)
+    s = ss.Samples.new(resultsdir, outputs, identifiers=["p_death"], verbose=False)
+    return s
+
 if __name__ == '__main__':
     samples = test_samples()
     samples = test_samples_no_identifier()
+    samples = test_verbose()
     results = test_dataset()


### PR DESCRIPTION
### Description
Retrieving items from a samples object causes a Value Error `ValueError: Index t invalid` in `samples.py` in line 390. 
Example: Retrieving an item in `test_samples()` in `test_samples.py`: 

```
  outputs = get_outputs(0.2)
  resultsdir = tempdir/'samples_results'
  resultsdir.mkdir(exist_ok=True)
  s = ss.Samples.new(resultsdir, outputs, identifiers=["p_death"])
  s[0]

```
This was likely missed in the starsim 2.0 update and is fixed by updating from `t` to `timevec`. 