### PR TITLE
Rc2.3 calib

### DIFF
--- a/docs/tutorials/tut_calibration.ipynb
+++ b/docs/tutorials/tut_calibration.ipynb
@@ -350,7 +350,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = calib.plot_final(); # Run the model for 10 replicates\n",
+    "g = calib.plot_final(); # Run the model for build_kw['n_reps'] = 15 replicates\n",
     "for ax in g.axes: # Fix the date formatting\n",
     "    ax.xaxis.set_major_formatter(mdates.ConciseDateFormatter(ax.xaxis.get_major_locator()))"
    ]

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -598,7 +598,6 @@ class Normal(CalibComponent):
         t = data.iloc[0]['t']
         expected = self.expected.loc[[t]]
         e_x = expected['x'].values.flatten()[0]
-        kk = np.linspace(0, 1, 1000)
         nll = 0
         for idx, row in data.iterrows():
             a_x = row['x']
@@ -609,7 +608,9 @@ class Normal(CalibComponent):
                 ti = self.expected.index.get_loc(t)
                 sigma2 = sigma2[ti]
 
-            q = sps.norm(loc=a_x, scale=np.sqrt(sigma2))
+            sigma = np.sqrt(sigma2)
+            kk = np.linspace(a_x - 1.96*sigma, a_x + 1.96*sigma, 1000)
+            q = sps.norm(loc=a_x, scale=sigma)
 
             yy = q.pdf(kk)
             plt.step(kk, yy, label=f"{row['rand_seed']}")

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -179,10 +179,10 @@ class CalibComponent(sc.prettyobj):
         # Bootstrapped aggregation
         boot_size = len(seeds)
         nlls = np.zeros(self.n_boot)
+        timecols = [c for c in self.actual.columns if isinstance(self.actual[c].iloc[0], dt.datetime)] # Not robust to data types
         for bi in range(self.n_boot):
             use_seeds = np.random.choice(seeds, boot_size, replace=True)
             actual = self.actual.loc[use_seeds]
-            timecols = [c for c in actual.columns if isinstance(actual[c].iloc[0], dt.datetime)] # Not very robust
             a_boot = actual.groupby(timecols).aggregate(func=self.combine_reps, **self.combine_kwargs)
             a_boot['rand_seed'] = bi # Fake the seed
             a_boot = a_boot.reset_index().set_index('rand_seed') # Make it look like self.actual

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -161,6 +161,7 @@ class CalibComponent(sc.prettyobj):
                 actuals.append(actual)
 
             if len(actuals) == 0: # No sims met the include criteria
+                self.actual = None
                 return np.inf
         else:
             assert self.include_fn is None, 'The include_fn argument is only valid for MultiSim objects'
@@ -199,8 +200,9 @@ class CalibComponent(sc.prettyobj):
         return f'Calibration component with name {self.name}'
 
     def plot(self, actual=None, bootstrap=False, **kwargs):
+        actual = self.actual if actual is None else actual
         if actual is None:
-            actual = self.actual
+            return None # Nothing to do
 
         if 'calibrated' not in actual.columns:
             actual['calibrated'] = 'Calibration'

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -610,7 +610,7 @@ class Normal(CalibComponent):
 
             # TEMP TODO calculate rate if 'n' supplied
             if 'n' in row:
-                a_x = row['x'].values / row['n'].values
+                a_x = row[['x']].values[0] / row[['n']].values[0]
 
             sigma2 = self.sigma2 if self.sigma2 is not None else self.compute_var(e_x, a_x)
             if isinstance(sigma2, (list, np.ndarray)):

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -610,7 +610,7 @@ class Normal(CalibComponent):
 
             # TEMP TODO calculate rate if 'n' supplied
             if 'n' in row:
-                a_x = row[['x']].values[0] / row[['n']].values[0]
+                a_x = row['x'] / row['n'] # row[['x']].values[0] / row[['n']].values[0]
 
             sigma2 = self.sigma2 if self.sigma2 is not None else self.compute_var(e_x, a_x)
             if isinstance(sigma2, (list, np.ndarray)):
@@ -648,7 +648,7 @@ class Normal(CalibComponent):
 
             # TEMP TODO calculate rate if 'n' supplied
             if 'n' in row:
-                a_x = row['x'].values / row['n'].values
+                a_x = row['x'] / row['n'] #row['x'].values / row['n'].values
 
             sigma2 = self.sigma2 if self.sigma2 is not None else self.compute_var(e_x, a_x)
             if isinstance(sigma2, (list, np.ndarray)):

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -577,6 +577,10 @@ class Normal(CalibComponent):
             e_x = rep['x_e'].values
             a_x = rep['x_a'].values
 
+            # TEMP TODO calculate rate if 'n' supplied
+            if 'n' in rep:
+                a_x = rep['x_a'].values / rep['n'].values
+
             if compute_var:
                 sigma2 = self.compute_var(expected['x'], a_x)
 
@@ -603,6 +607,11 @@ class Normal(CalibComponent):
         nll = 0
         for idx, row in data.iterrows():
             a_x = row['x']
+
+            # TEMP TODO calculate rate if 'n' supplied
+            if 'n' in row:
+                a_x = row['x'].values / row['n'].values
+
             sigma2 = self.sigma2 if self.sigma2 is not None else self.compute_var(e_x, a_x)
             if isinstance(sigma2, (list, np.ndarray)):
                 assert len(sigma2) == len(self.expected), 'Length of sigma2 must match the number of timepoints'
@@ -636,6 +645,11 @@ class Normal(CalibComponent):
             row = data.set_index('rand_seed').loc[use_seeds].groupby('t').aggregate(func=self.combine_reps, **self.combine_kwargs)
 
             a_x = row['x']
+
+            # TEMP TODO calculate rate if 'n' supplied
+            if 'n' in row:
+                a_x = row['x'].values / row['n'].values
+
             sigma2 = self.sigma2 if self.sigma2 is not None else self.compute_var(e_x, a_x)
             if isinstance(sigma2, (list, np.ndarray)):
                 assert len(sigma2) == len(self.expected), 'Length of sigma2 must match the number of timepoints'
@@ -644,7 +658,7 @@ class Normal(CalibComponent):
                 sigma2 = sigma2[ti]
 
             q = sps.norm(loc=a_x, scale=np.sqrt(sigma2))
-            means[bi] = q.mean()
+            means[bi] = q.mean() # Will just be a_x, TODO: streamline
 
         ax = sns.kdeplot(means)
         sns.rugplot(means, ax=ax)

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -161,7 +161,7 @@ class CalibComponent(sc.prettyobj):
                 actuals.append(actual)
 
             if len(actuals) == 0: # No sims met the include criteria
-                return -np.inf
+                return np.inf
         else:
             assert self.include_fn is None, 'The include_fn argument is only valid for MultiSim objects'
             actual = self.extract_fn(sim) # Extract

--- a/starsim/calibration.py
+++ b/starsim/calibration.py
@@ -280,12 +280,18 @@ class Calibration(sc.prettyobj):
 
         return self
 
-    def save_csv(self, filename):
+    def save_csv(self, filename, top_k=None):
         """ Save the results to a CSV file """
         if self.study is None:
             raise ValueError('Please run calibrate() before saving results')
 
-        df = self.study.trials_dataframe()
+        df = self.study.trials_dataframe() \
+            .sort_values(by='value') \
+            .set_index('number')
+
+        if top_k is not None:
+            df = df.head(top_k)
+
         df.to_csv(filename)
         return df
 

--- a/starsim/calibration.py
+++ b/starsim/calibration.py
@@ -220,7 +220,11 @@ class Calibration(sc.prettyobj):
         except op.exceptions.DuplicatedStudyError:
             ss.warn(f'Study named {self.run_args.study_name} already exists in storage {self.run_args.storage}, loading...')
             study = op.create_study(storage=self.run_args.storage, study_name=self.run_args.study_name, direction='minimize', load_if_exists=True)
-            self.best_pars = sc.objdict(study.best_params)
+            try:
+                self.best_pars = sc.objdict(study.best_params)
+            except Exception as E:
+                print(f'Could not get best parameters: {str(E)}')
+                self.best_pars = None
         return study
 
     def calibrate(self, calib_pars=None, load=False, tidyup=True, **kwargs):

--- a/starsim/networks.py
+++ b/starsim/networks.py
@@ -1253,8 +1253,6 @@ class MixingPool(Route):
         self.src_uids = self.get_uids(self.pars.src)
         self.dst_uids = self.get_uids(self.pars.dst)
         beta = self.pars.beta
-        if isinstance(beta, ss.beta):
-            beta = beta.values # Don't use as a time probability
 
         if beta == 0:
             return 0

--- a/starsim/parameters.py
+++ b/starsim/parameters.py
@@ -6,11 +6,12 @@ import numpy as np
 import pandas as pd
 import sciris as sc
 import starsim as ss
+import datetime as dt
 
 __all__ = ['Pars', 'SimPars', 'make_pars']
 
 # Define classes to not descend into further -- based on sciris.sc_nested
-atomic_classes = (str, Number, list, np.ndarray, pd.Series, pd.DataFrame, type(None))
+atomic_classes = (str, Number, list, np.ndarray, pd.Series, pd.DataFrame, type(None), dt.date)
 
 
 class Pars(sc.objdict):


### PR DESCRIPTION
### Description
Adds a flag `continue_db` to calibration. Also allows the user to save calibration results using `save_csv`.

Also addresses #826 

### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released