### PR TITLE
Operators work directly on raw arrays if most agents are active

### DIFF
--- a/starsim/arrays.py
+++ b/starsim/arrays.py
@@ -369,18 +369,41 @@ class Arr(BaseArr):
         return
 
     def asnew(self, arr=None, cls=None, name=None, raw=None):
-        """ Duplicate and copy (rather than link) data, optionally resetting the array """
+        """
+        Duplicate and copy (rather than link) data, optionally resetting the array
+
+        The values in the new array are drawn from one of three options
+            - If a `raw` array is specified, it will be used for the new array directly (not copied)
+            - Otherwise, if `arr` is specified, it will be used for the values in the new array (for active agents only)
+            - Otherwise, a copy of the `raw` array for the Arr instance will be used
+
+        Passing in a `raw` array directly is a performance optimization when the calling code has
+        already generated a suitable array that does not need to be copied again.
+
+        Args:
+            arr: The array to use for values, with length matching the number of active UIDs
+            cls: The class to use for the new array
+            name: The name to use for the new array
+            raw: The raw array to use for the new array
+
+
+        """
         if cls is None:
             cls = self.__class__
-        if arr is None:
-            if raw is not None:
-                arr = raw
-            else:
-                arr = self.values
+
+        if raw is None and arr is None:
+            raw = self.raw.copy()
+
+        if raw is not None:
+            dtype = raw.dtype
+        else:
+            dtype = arr.dtype
+
         new = object.__new__(cls) # Create a new Arr instance
         new.__dict__ = self.__dict__.copy() # Copy pointers
-        new.dtype = arr.dtype # Set to correct dtype
+        new.dtype = dtype # Set to correct dtype
         new.name = name # In most cases, the asnew Arr has different values to the original Arr so the original name no longer makes sense
+
         if raw is not None:
             new.raw = raw
         else:
@@ -389,6 +412,7 @@ class Arr(BaseArr):
         return new
 
     def true(self):
+
         """ Efficiently convert truthy values to UIDs """
         return self.auids[self.values.astype(bool)]
 


### PR DESCRIPTION
### Description

Operators on `Arr` and `BoolArr` use `asnew()` to return new `Arr` instances. These work along the lines of

- Using `self.values` to create a numpy array with length equal to `auids`
- Creating a corresponding array from `other.values` if `other` is an `Arr`
- Creating an intermediate result array with length equal to `auids`
- Creating a new empty array the same size as `uids`
- Populating it sparsely with the result array based on `auids` 

The intention is that the alternative of operating on every UID (i.e., on the `raw` arrays directly) would be unnecessarily slow if there are many inactive agents. However, in practice the overhead associated with creating the intermediate arrays and then sparsely inserting it is fairly significant. For simulations that do not have a significant proportion of inactive agents, it can be faster to just operate on every entry. In that case, no intermediate arrays need to be created - the output of the logical operation of the two raw arrays can be directly used as the raw array for the new `Arr` instances. In some simulations this can give a speedup of around 40%.

This PR thus adds an attribute for `Arr` that corresponds to whether this optimization should be used, with a threshold of 50% (i.e., it will use the raw entries if over half the agents are active). This threshold could be tuned as we get more use cases. There is a corresponding update to `asnew` to optionally take in a `raw` array, which will be used if provided.

There should be no changes necessary in any user code and simulation output should be the same

### Checklist
- [x] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released