### PR TITLE
Rc2.3 calib betafix

### DIFF
--- a/docs/tutorials/tut_calibration.ipynb
+++ b/docs/tutorials/tut_calibration.ipynb
@@ -350,7 +350,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = calib.plot_final(); # Run the model for 10 replicates\n",
+    "g = calib.plot_final(); # Run the model for build_kw['n_reps'] = 15 replicates\n",
     "for ax in g.axes: # Fix the date formatting\n",
     "    ax.xaxis.set_major_formatter(mdates.ConciseDateFormatter(ax.xaxis.get_major_locator()))"
    ]

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -379,7 +379,7 @@ class Binomial(CalibComponent):
             else:
                 actual = data.set_index('rand_seed').loc[use_seeds].groupby('t').aggregate(func=self.combine_reps, **self.combine_kwargs)
 
-            for row in actual.iterrows():
+            for idx, row in actual.iterrows():
                 p = self.get_p(row)
                 q = sps.binom(n=e_n, p=p)
                 means[bi] = q.mean()
@@ -554,7 +554,7 @@ class GammaPoisson(CalibComponent):
             else:
                 actual = data.set_index('rand_seed').loc[use_seeds].groupby(['t', 't1']).aggregate(func=self.combine_reps, **self.combine_kwargs)
 
-            for row in actual.iterrows():
+            for idx, row in actual.iterrows():
                 a_n, a_x = row['n'], row['x']
                 beta = (a_n+1)
                 T = e_n

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -178,7 +178,9 @@ class CalibComponent(sc.prettyobj):
                 self.actual = None
                 return np.inf
         else:
-            assert self.include_fn is None, 'The include_fn argument is only valid for MultiSim objects'
+            # Warn if the user has an include_fn for a single sim
+            if self.include_fn is not None and not self.include_fn(sim):
+                sc.printv(f'Warning: include_fn was specified for a single simulation, but will be ignored', level=1)
             actual = self.extract_fn(sim) # Extract
             if self.conform is not None:
                 actual = self.conform(self.expected, actual) # Conform

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -346,14 +346,12 @@ class Binomial(CalibComponent):
             if 'p' in rep:
                 # p specified, no collision
                 e_n, e_x = rep['n'], rep['x']
-                if e_n == 0:
-                    return np.inf
                 p = self.get_p(rep)
             else:
                 assert 'n_e' in rep and 'x_e' in rep, 'Expected columns n_e and x_e not found'
                 # Collision in merge, get _e and _a values
                 e_n, e_x = rep['n_e'], rep['x_e']
-                if e_n == 0:
+                if rep['n_a'] == 0:
                     return np.inf
                 p = self.get_p(rep, 'x_a', 'n_a')
 

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -111,10 +111,10 @@ class CalibComponent(sc.prettyobj):
         weight (float): The weight applied to the log likelihood of this component. The total log likelihood is the sum of the log likelihoods of all components, each multiplied by its weight.
         include_fn (callable): A function accepting a single simulation and returning a boolean to determine if the simulation should be included in the current component. If None, all simulations are included.
         n_boot (int): Experimental! Bootstrap sum sim results over seeds before comparing against expected results. Not appropriate for all component types.
-        combine_reps (str): How to combine multiple repetitions of the same pars. Options are 'mean' and 'sum'. Default is 'mean'. Used if n_boot>1 and for plotting with bootstrap=True.
+        combine_reps (str): How to combine multiple repetitions of the same pars. Options are None, 'mean', 'sum', or other such operation. Default is None, which evaluates replicates independently instead of first combining before likelihood evaluation.
         kwargs: Additional arguments to pass to the likelihood function
     """
-    def __init__(self, name, expected, extract_fn, conform, weight=1, include_fn=None, n_boot=None, combine_reps='mean'):
+    def __init__(self, name, expected, extract_fn, conform, weight=1, include_fn=None, n_boot=None, combine_reps=None):
         self.name = name
         self.expected = expected
         self.extract_fn = extract_fn
@@ -128,6 +128,7 @@ class CalibComponent(sc.prettyobj):
             self.combine_kwargs = dict(numeric_only=True)
 
         self.avail_conforms = {
+            'none': None, # passthrough
             'incident':  linear_accum,  # or self.linear_accum if left as staticmethod  
             'prevalent': linear_interp,
             'step_containing': step_containing,
@@ -140,13 +141,24 @@ class CalibComponent(sc.prettyobj):
         if not isinstance(conform, str) and not callable(conform):  
             raise Exception(f"The conform argument must be a string or a callable function, not {type(conform)}.")  
         elif isinstance(conform, str):  
-            conform_ = self.avail_conforms.get(conform)  
-            if conform_ is None:  
+            conform_ = self.avail_conforms.get(conform.lower(), 'NOT FOUND')
+            if conform_ == 'NOT FOUND':
                 avail = self.avail_conforms.keys()  
                 raise ValueError(f"The conform argument must be one of {avail}, not {conform}.")  
         else:  
             conform_ = conform  
-        return conform_  
+        return conform_
+
+    def _combine_reps_nll(self, expected, actual, **kwargs):
+        if self.combine_reps is None:
+            nll = self.compute_nll(expected, actual, **kwargs) # Negative log likelihood
+        else:
+            timecols = [c for c in self.actual.columns if isinstance(self.actual[c].iloc[0], dt.datetime)] # Not robust to data types
+            actual_combined = actual.groupby(timecols).aggregate(func=self.combine_reps, **self.combine_kwargs)
+            actual_combined['rand_seed'] = 0 # Fake the seed
+            actual_combined = actual_combined.reset_index().set_index('rand_seed') # Make it look like self.actual
+            nll = self.compute_nll(expected, actual_combined, **kwargs)
+        return nll
 
     def eval(self, sim, **kwargs):
         """ Compute and return the negative log likelihood """
@@ -156,7 +168,8 @@ class CalibComponent(sc.prettyobj):
                 if self.include_fn is not None and not self.include_fn(s):
                     continue # Skip this simulation
                 actual = self.extract_fn(s)
-                actual = self.conform(self.expected, actual) # Conform
+                if self.conform is not None:
+                    actual = self.conform(self.expected, actual) # Conform
                 actual['rand_seed'] = s.pars.rand_seed
                 actuals.append(actual)
 
@@ -166,7 +179,8 @@ class CalibComponent(sc.prettyobj):
         else:
             assert self.include_fn is None, 'The include_fn argument is only valid for MultiSim objects'
             actual = self.extract_fn(sim) # Extract
-            actual = self.conform(self.expected, actual) # Conform
+            if self.conform is not None:
+                actual = self.conform(self.expected, actual) # Conform
             actual['rand_seed'] = sim.pars.rand_seed
             actuals = [actual]
 
@@ -174,22 +188,18 @@ class CalibComponent(sc.prettyobj):
         seeds = self.actual.index.unique()
 
         if self.n_boot is None or self.n_boot == 1 or len(seeds) == 1:
-            self.nll = self.compute_nll(self.expected, self.actual, **kwargs) # Negative log likelihood
-            return self.weight * np.sum(self.nll)
+            self.nll = self._combine_reps_nll(self.expected, self.actual, **kwargs)
+            return self.weight * np.mean(self.nll)
 
         # Bootstrapped aggregation
         boot_size = len(seeds)
         nlls = np.zeros(self.n_boot)
-        timecols = [c for c in self.actual.columns if isinstance(self.actual[c].iloc[0], dt.datetime)] # Not robust to data types
         for bi in range(self.n_boot):
             use_seeds = np.random.choice(seeds, boot_size, replace=True)
             actual = self.actual.loc[use_seeds]
-            a_boot = actual.groupby(timecols).aggregate(func=self.combine_reps, **self.combine_kwargs)
-            a_boot['rand_seed'] = bi # Fake the seed
-            a_boot = a_boot.reset_index().set_index('rand_seed') # Make it look like self.actual
-            nll = self.compute_nll(self.expected, a_boot, **kwargs)
-            nlls[bi] = np.sum(nll)
-        self.nll = np.mean(nlls) # Mean of bootstrapped nlls
+            nll = self._combine_reps_nll(self.expected, actual, **kwargs)
+            nlls[bi] = np.mean(nll) # Mean across reps
+        self.nll = np.mean(nlls) # Mean across bootstraps
 
         return self.weight * self.nll
 
@@ -218,7 +228,7 @@ class CalibComponent(sc.prettyobj):
             if row_val == g.row_names[0] and isinstance(col_val, dt.datetime):
                 ax.set_title(col_val.strftime('%Y-%m-%d'))
 
-        g.fig.subplots_adjust(top=0.9)
+        g.fig.subplots_adjust(top=0.8)
         g.fig.suptitle(self.name)
         return g.fig
 
@@ -246,9 +256,9 @@ class BetaBinomial(CalibComponent):
         logLs = []
 
         combined = pd.merge(expected.reset_index(), actual.reset_index(), on=['t'], suffixes=('_e', '_a'))
-        for seed, rep in combined.groupby('rand_seed'):
-            e_n, e_x = rep['n_e'].values, rep['x_e'].values
-            a_n, a_x = rep['n_a'].values, rep['x_a'].values
+        for idx, rep in combined.iterrows():
+            e_n, e_x = rep['n_e'], rep['x_e']
+            a_n, a_x = rep['n_a'], rep['x_a']
 
             logL = sps.betabinom.logpmf(k=e_x, n=e_n, a=a_x+1, b=a_n-a_x+1)
             logLs.append(logL)
@@ -283,12 +293,16 @@ class BetaBinomial(CalibComponent):
         means = np.zeros(n_boot)
         for bi in np.arange(n_boot):
             use_seeds = np.random.choice(seeds, boot_size, replace=True)
-            row = data.set_index('rand_seed').loc[use_seeds].groupby('t').aggregate(func=self.combine_reps, **self.combine_kwargs)
+            if self.combine_reps is None:
+                actual = data.set_index('rand_seed').loc[use_seeds]
+            else:
+                actual = data.set_index('rand_seed').loc[use_seeds].groupby('t').aggregate(func=self.combine_reps, **self.combine_kwargs)
 
-            alpha = row['x'] + 1
-            beta = row['n'] - row['x'] + 1
-            q = sps.betabinom(n=e_n, a=alpha, b=beta)
-            means[bi] = q.mean()
+            for row in actual.iterrows():
+                alpha = row['x'] + 1
+                beta = row['n'] - row['x'] + 1
+                q = sps.betabinom(n=e_n, a=alpha, b=beta)
+                means[bi] = q.mean()
 
         ax = sns.kdeplot(means)
         sns.rugplot(means, ax=ax)
@@ -316,15 +330,15 @@ class Binomial(CalibComponent):
         logLs = []
 
         combined = pd.merge(expected.reset_index(), actual.reset_index(), on=['t'], suffixes=('_e', '_a'))
-        for seed, rep in combined.groupby('rand_seed'):
+        for idx, rep in combined.iterrows():
             if 'p' in rep:
                 # p specified, no collision
-                e_n, e_x = rep['n'].values, rep['x'].values 
+                e_n, e_x = rep['n'], rep['x']
                 p = self.get_p(rep)
             else:
                 assert 'n_e' in rep and 'x_e' in rep, 'Expected columns n_e and x_e not found'
                 # Collision in merge, get _e and _a values
-                e_n, e_x = rep['n_e'].values, rep['x_e'].values 
+                e_n, e_x = rep['n_e'], rep['x_e']
                 p = self.get_p(rep, 'x_a', 'n_a')
 
             logL = sps.binom.logpmf(k=e_x, n=e_n, p=p)
@@ -359,11 +373,15 @@ class Binomial(CalibComponent):
         means = np.zeros(n_boot)
         for bi in np.arange(n_boot):
             use_seeds = np.random.choice(seeds, boot_size, replace=True)
-            row = data.set_index('rand_seed').loc[use_seeds].groupby('t').aggregate(func=self.combine_reps, **self.combine_kwargs)
+            if self.combine_reps is None:
+                actual = data.set_index('rand_seed').loc[use_seeds]
+            else:
+                actual = data.set_index('rand_seed').loc[use_seeds].groupby('t').aggregate(func=self.combine_reps, **self.combine_kwargs)
 
-            p = self.get_p(row)
-            q = sps.binom(n=e_n, p=p)
-            means[bi] = q.mean()
+            for row in actual.iterrows():
+                p = self.get_p(row)
+                q = sps.binom(n=e_n, p=p)
+                means[bi] = q.mean()
 
         ax = sns.kdeplot(means)
         sns.rugplot(means, ax=ax)
@@ -390,10 +408,10 @@ class DirichletMultinomial(CalibComponent):
         logLs = []
         x_vars = [xkey for xkey in expected.columns if xkey.startswith('x')]
         for t, rep_t in actual.groupby('t'):
-            for seed, rep in rep_t.groupby('rand_seed'):
-                e_x = expected.loc[t, x_vars].values[0]
+            for idx, rep in rep_t.iterrows():
+                e_x = expected.loc[t, x_vars].values.flatten()
                 n = e_x.sum()
-                a_x = rep[x_vars].values[0]
+                a_x = rep[x_vars].astype('float')
                 logL = sps.dirichlet_multinomial.logpmf(x=e_x, n=n, alpha=a_x+1)
                 logLs.append(logL)
 
@@ -486,13 +504,13 @@ class GammaPoisson(CalibComponent):
         logLs = []
 
         combined = pd.merge(expected.reset_index(), actual.reset_index(), on=['t', 't1'], suffixes=('_e', '_a'))
-        for seed, rep in combined.groupby('rand_seed'):
-            e_n, e_x = rep['n_e'].values, rep['x_e'].values
-            a_n, a_x = rep['n_a'].values, rep['x_a'].values
+        for idx, rep in combined.iterrows():
+            e_n, e_x = rep['n_e'], rep['x_e']
+            a_n, a_x = rep['n_a'], rep['x_a']
             T = e_n
             beta = 1 + a_n
             logL = sps.nbinom.logpmf(k=e_x, n=1+a_x, p=beta/(beta+T))
-            np.nan_to_num(logL, nan=-np.inf, copy=False)
+            logL = np.nan_to_num(logL, nan=-np.inf)
             logLs.append(logL)
 
         nlls = -np.array(logLs)
@@ -529,13 +547,18 @@ class GammaPoisson(CalibComponent):
         means = np.zeros(n_boot)
         for bi in np.arange(n_boot):
             use_seeds = np.random.choice(seeds, boot_size, replace=True)
-            row = data.set_index('rand_seed').loc[use_seeds].groupby(['t', 't1']).aggregate(func=self.combine_reps, **self.combine_kwargs)
 
-            a_n, a_x = row['n'], row['x']
-            beta = (a_n+1)
-            T = e_n
-            q = sps.nbinom(n=1+a_x, p=beta/(beta+T))
-            means[bi] = q.mean()
+            if self.combine_reps is None:
+                actual = data.set_index('rand_seed').loc[use_seeds]
+            else:
+                actual = data.set_index('rand_seed').loc[use_seeds].groupby(['t', 't1']).aggregate(func=self.combine_reps, **self.combine_kwargs)
+
+            for row in actual.iterrows():
+                a_n, a_x = row['n'], row['x']
+                beta = (a_n+1)
+                T = e_n
+                q = sps.nbinom(n=1+a_x, p=beta/(beta+T))
+                means[bi] = q.mean()
 
         ax = sns.kdeplot(means)
         sns.rugplot(means, ax=ax)
@@ -573,13 +596,13 @@ class Normal(CalibComponent):
         compute_var = sigma2 is None
 
         combined = pd.merge(expected.reset_index(), actual.reset_index(), on=['t'], suffixes=('_e', '_a'))
-        for seed, rep in combined.groupby('rand_seed'):
-            e_x = rep['x_e'].values
-            a_x = rep['x_a'].values
+        for idx, rep in combined.iterrows():
+            e_x = rep['x_e']
+            a_x = rep['x_a']
 
             # TEMP TODO calculate rate if 'n' supplied
             if 'n' in rep:
-                a_x = rep['x_a'].values / rep['n'].values
+                a_x = rep['x_a'] / rep['n']
 
             if compute_var:
                 sigma2 = self.compute_var(expected['x'], a_x)
@@ -642,23 +665,21 @@ class Normal(CalibComponent):
         means = np.zeros(n_boot)
         for bi in np.arange(n_boot):
             use_seeds = np.random.choice(seeds, boot_size, replace=True)
-            row = data.set_index('rand_seed').loc[use_seeds].groupby('t').aggregate(func=self.combine_reps, **self.combine_kwargs)
 
-            a_x = row['x']
+            if self.combine_reps is None:
+                actual = data.set_index('rand_seed').loc[use_seeds]
+            else:
+                actual = data.set_index('rand_seed').loc[use_seeds].groupby('t').aggregate(func=self.combine_reps, **self.combine_kwargs)
 
-            # TEMP TODO calculate rate if 'n' supplied
-            if 'n' in row:
-                a_x = row['x'] / row['n'] #row['x'].values / row['n'].values
+            for idx, row in actual.iterrows():
+                a_x = row['x']
 
-            sigma2 = self.sigma2 if self.sigma2 is not None else self.compute_var(e_x, a_x)
-            if isinstance(sigma2, (list, np.ndarray)):
-                assert len(sigma2) == len(self.expected), 'Length of sigma2 must match the number of timepoints'
-                # User provided a vector of variances
-                ti = self.expected.index.get_loc(t)
-                sigma2 = sigma2[ti]
+                # TEMP TODO calculate rate if 'n' supplied
+                if 'n' in row:
+                    a_x = row['x'] / row['n'] #row['x'].values / row['n'].values
 
-            q = sps.norm(loc=a_x, scale=np.sqrt(sigma2))
-            means[bi] = q.mean() # Will just be a_x, TODO: streamline
+                # No need to form the sps.norm involving sigma2 because the mean will be a_x
+                means[bi] = a_x
 
         ax = sns.kdeplot(means)
         sns.rugplot(means, ax=ax)

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -338,11 +338,15 @@ class Binomial(CalibComponent):
             if 'p' in rep:
                 # p specified, no collision
                 e_n, e_x = rep['n'], rep['x']
+                if e_n == 0:
+                    return np.inf
                 p = self.get_p(rep)
             else:
                 assert 'n_e' in rep and 'x_e' in rep, 'Expected columns n_e and x_e not found'
                 # Collision in merge, get _e and _a values
                 e_n, e_x = rep['n_e'], rep['x_e']
+                if e_n == 0:
+                    return np.inf
                 p = self.get_p(rep, 'x_a', 'n_a')
 
             logL = sps.binom.logpmf(k=e_x, n=e_n, p=p)

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -317,7 +317,7 @@ class Binomial(CalibComponent):
         if 'p' in df:
             p = df['p'].values
         else:
-            p = (df[x_col]+1) / (df[n_col]+2)
+            p = df[x_col] / df[n_col] # Switched to MLE x/n from previous "Bayesian" (Laplace +1, Jeffreys) before: (df[x_col]+1) / (df[n_col]+2)
         return p
 
     def compute_nll(self, expected, actual, **kwargs):

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -202,6 +202,9 @@ class CalibComponent(sc.prettyobj):
             nlls[bi] = np.mean(nll) # Mean across reps
         self.nll = np.mean(nlls) # Mean across bootstraps
 
+        if np.isnan(self.nll):
+            return np.inf # Convert nan to inf
+
         return self.weight * self.nll
 
     def __call__(self, sim, **kwargs):

--- a/starsim/calib_components.py
+++ b/starsim/calib_components.py
@@ -123,6 +123,7 @@ class CalibComponent(sc.prettyobj):
         self.n_boot = n_boot
 
         self.combine_reps = combine_reps
+        self.combine_kwargs = dict()
         if isinstance(self.combine_reps, str) and hasattr(pd.core.groupby.DataFrameGroupBy, self.combine_reps):
             # Most of these methods take numeric_only, which can help with stability
             self.combine_kwargs = dict(numeric_only=True)

--- a/starsim/calibration.py
+++ b/starsim/calibration.py
@@ -84,8 +84,6 @@ class Calibration(sc.prettyobj):
 
         self.study = None
 
-        # Temporarily store a filename for storing intermediate results
-        self.tmp_filename = 'tmp_calibration_%06i.obj'
         return
 
     def run_sim(self, calib_pars=None, label=None):

--- a/starsim/calibration.py
+++ b/starsim/calibration.py
@@ -233,15 +233,12 @@ class Calibration(sc.prettyobj):
                 self.best_pars = None
         return study
 
-    def calibrate(self, calib_pars=None, load=False, tidyup=True, **kwargs):
+    def calibrate(self, calib_pars=None, **kwargs):
         """
         Perform calibration.
 
         Args:
             calib_pars (dict): if supplied, overwrite stored calib_pars
-            load (bool): whether to load existing trials from the database (if rerunning the same calibration)
-            tidyup (bool): whether to delete temporary files from trial runs
-            verbose (bool): whether to print output from each trial
             kwargs (dict): if supplied, overwrite stored run_args (n_trials, n_workers, etc.)
         """
         # Load and validate calibration parameters
@@ -257,28 +254,7 @@ class Calibration(sc.prettyobj):
         self.best_pars = sc.objdict(study.best_params)
         self.elapsed = sc.toc(t0, output=True)
 
-        self.sim_results = []
-        if load:
-            if self.verbose: print('Loading saved results...')
-            for trial in study.trials:
-                n = trial.number
-                try:
-                    filename = self.tmp_filename % trial.number
-                    results = sc.load(filename)
-                    self.sim_results.append(results)
-                    if tidyup:
-                        try:
-                            os.remove(filename)
-                            if self.verbose: print(f'    Removed temporary file {filename}')
-                        except Exception as E:
-                            errormsg = f'Could not remove {filename}: {str(E)}'
-                            if self.verbose: print(errormsg)
-                    if self.verbose: print(f'  Loaded trial {n}')
-                except Exception as E:
-                    errormsg = f'Warning, could not load trial {n}: {str(E)}'
-                    if self.verbose: print(errormsg)
-
-        # Compare the results
+        # Parse the study into a data frame, self.df while also storing the best parameters
         self.parse_study(study)
 
         if self.verbose: print('Best pars:', self.best_pars)

--- a/starsim/calibration.py
+++ b/starsim/calibration.py
@@ -297,7 +297,7 @@ class Calibration(sc.prettyobj):
 
         after_pars = sc.dcp(self.calib_pars)
         for parname, spec in after_pars.items():
-            spec['value'] = self.best_pars[parname]
+            spec['value'] = self.best_pars[parname] # Use best parameters from calibration
 
         self.before_msim = self.build_fn(self.sim.copy(), calib_pars=before_pars, **self.build_kw)
         self.after_msim = self.build_fn(self.sim.copy(), calib_pars=after_pars, **self.build_kw)
@@ -395,7 +395,7 @@ class Calibration(sc.prettyobj):
 
         pars = sc.dcp(self.calib_pars)
         for parname, spec in pars.items():
-            spec['value'] = self.best_pars[parname]
+            spec['value'] = self.best_pars[parname] # Use best parameters from calibration
         msim = self.build_fn(self.sim.copy(), calib_pars=pars, **self.build_kw)
 
         msim.run()

--- a/starsim/calibration.py
+++ b/starsim/calibration.py
@@ -332,10 +332,10 @@ class Calibration(sc.prettyobj):
         fix_after = isinstance(self.after_msim, ss.Sim)
         if fix_after or fix_after:
             if fix_before:
-                self.before_msim = ss.MultiSim(self.before_msim, initialize=True, debug=True, parallel=False)
+                self.before_msim = ss.MultiSim(self.before_msim, initialize=True, debug=True, parallel=False, n_runs=1)
 
             if fix_after:
-                self.after_msim = ss.MultiSim(self.after_msim, initialize=True, debug=True, parallel=False)
+                self.after_msim = ss.MultiSim(self.after_msim, initialize=True, debug=True, parallel=False, n_runs=1)
 
         msim = ss.MultiSim(self.before_msim.sims + self.after_msim.sims)
         msim.run()

--- a/starsim/networks.py
+++ b/starsim/networks.py
@@ -1253,8 +1253,6 @@ class MixingPool(Route):
         self.src_uids = self.get_uids(self.pars.src)
         self.dst_uids = self.get_uids(self.pars.dst)
         beta = self.pars.beta
-        if isinstance(beta, ss.beta):
-            beta = beta.values # Don't use as a time probability
 
         if beta == 0:
             return 0


### PR DESCRIPTION
### Description
* Adding a 'none' conformer that bypasses conforming - addresses #850
* Separated combining replicates from bootstrapping. The default combine_reps is now None, which bypasses combining replicates.
* Now taking the mean across replicates instead of the sum. This change is important if using the `include_fn` and some replicates are rejected, resulting in a varying number of replicates across input parameter sets. The mean is the right operation here, not the sum.
* Fix a bug that was causing check_fit to do 4 replicates even when the user did not ask for replicates.
* Re-enabling calibration tests.

Avoids converting ss.beta to "values" before multiplying computing transmission, partly addressing #846.

### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released