### PR TITLE
Removed .par from validate_verbose error msg

### DIFF
--- a/starsim/parameters.py
+++ b/starsim/parameters.py
@@ -299,7 +299,7 @@ class SimPars(Pars):
         if self.verbose == 'brief':
             self.verbose = -1
         if not sc.isnumber(self.verbose):  # pragma: no cover
-            errormsg = f'Verbose argument should be either "brief", -1, or a float, not {type(self.par.verbose)} "{self.par.verbose}"'
+            errormsg = f'Verbose argument should be either "brief", -1, or a float, not {type(self.verbose)} "{self.verbose}"'
             raise ValueError(errormsg)
         return
 


### PR DESCRIPTION
### Description
Fixes #891. Just needed to remove .par from the object paths in the error message of validate_verbose().

### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released