### PR TITLE
fix: update numba dependency to require >=0.57.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "numpy>=1.24.0",
     "pandas>=2.0.0",
     "sciris>=3.2.0",
-    "numba",
+    "numba>=0.57.0",
     "scipy",
     "networkx",
     "matplotlib",


### PR DESCRIPTION
### Description

I was installing Starsim with [uv](https://github.com/astral-sh/uv) and ran into the following issue when including numpy (and other often-used packages in analysis, but I found numpy was the key problem) as a dependency too, likely due to dependency version resolution issues: 

```
$ uv init test-starsim
error: Project is already initialized in `/Users/vsb/projects/test-starsim` (`pyproject.toml` file exists)
$ rm -rf test-starsim
$ uv init test-starsim
Initialized project `test-starsim` at `/Users/vsb/projects/test-starsim`
$ cd test-starsim
$ uv add numpy starsim
warning: `VIRTUAL_ENV=/Users/vsb/projects/starsim/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Using CPython 3.13.2 interpreter at: /opt/homebrew/opt/python@3.13/bin/python3.13
Creating virtual environment at: .venv
Resolved 49 packages in 13ms
  × Failed to build `numba==0.53.1`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
          requires = get_requires_for_build({})
        File "/Users/vsb/.cache/uv/builds-v0/.tmpGSUIsa/lib/python3.13/site-packages/setuptools/build_meta.py", line 334, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/vsb/.cache/uv/builds-v0/.tmpGSUIsa/lib/python3.13/site-packages/setuptools/build_meta.py", line 304, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/Users/vsb/.cache/uv/builds-v0/.tmpGSUIsa/lib/python3.13/site-packages/setuptools/build_meta.py", line 522, in run_setup
          super().run_setup(setup_script=setup_script)
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/vsb/.cache/uv/builds-v0/.tmpGSUIsa/lib/python3.13/site-packages/setuptools/build_meta.py", line 320, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 50, in <module>
        File "<string>", line 47, in _guard_py_ver
      RuntimeError: Cannot install on Python version 3.13.2; only versions >=3.6,<3.10 are supported.

      hint: This usually indicates a problem with the package or the build environment.
  help: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing.
```

This also manifested with a different combination of often-used Python data analysis tools as dependencies too as a slightly different error: 

```
$ uv add numpy starsim jupyterlab matplotlib scipy 
Using CPython 3.9.6 interpreter at: /Library/Developer/CommandLineTools/usr/bin/python3
Creating virtual environment at: .venv
Resolved 148 packages in 337ms
  × Failed to build llvmlite==0.36.0
  ├─▶ The build backend returned an error
  ╰─▶ Call to setuptools.build_meta:__legacy__.build_wheel failed (exit status: 1)
      [stdout]
      running bdist_wheel
      /Users/vsb/.cache/uv/builds-v0/.tmpF735Cc/bin/python /Users/vsb/.cache/uv/sdists-v9/pypi/llvmlite/0.36.0/YY65-dyEXG-Ok76-GBhPU/src/ffi/build.py
      LLVM version...
      [stderr]
      Traceback (most recent call last):
        File "/Users/vsb/.cache/uv/sdists-v9/pypi/llvmlite/0.36.0/YY65-dyEXG-Ok76-GBhPU/src/ffi/build.py", line 220, in <module>
          main()
        File "/Users/vsb/.cache/uv/sdists-v9/pypi/llvmlite/0.36.0/YY65-dyEXG-Ok76-GBhPU/src/ffi/build.py", line 214, in main
          main_posix('osx', '.dylib')
        File "/Users/vsb/.cache/uv/sdists-v9/pypi/llvmlite/0.36.0/YY65-dyEXG-Ok76-GBhPU/src/ffi/build.py", line 134, in main_posix
          raise RuntimeError(msg) from None
      RuntimeError: Could not find a llvm-config binary. There are a number of reasons this could occur, please see: https://llvmlite.readthedocs.io/en/latest/admin-guide/install.html#using-pip for help.
      error: command '/Users/vsb/.cache/uv/builds-v0/.tmpF735Cc/bin/python' failed with exit code 1
      hint: This usually indicates a problem with the package or the build environment.
  help: If you want to add the package regardless of the failed resolution, provide the --frozen flag to skip locking and syncing.
```

Both issues seem to be due to a numba not having a minimum version specified in `pyproject.toml`. This PR fixes these installation issues by adding a minimum version requirement for numba (`numba>=0.57.0`). This version is compatible with both modern Python versions (like 3.13) and modern LLVM installations (19+), ensuring smoother installation experience when using Starsim alongside other scientific computing packages.

### Checklist
- [ ] Code commented & docstrings added — Not applicable for this change.
- [ ] New tests were needed and have been added — Not applicable for this change. I did run tests, and they passed. 
- [ ] A new version number was needed & changelog has been updated — Not needed for this minor maintenance fix (but happy to create one if preferred).
- [ ] A new PyPI version needs to be released — Probably not needed. 