### PR TITLE
Restore MixingPool beta to 1.0 now that it is interpreted as a multiplier

### DIFF
--- a/starsim/networks.py
+++ b/starsim/networks.py
@@ -1189,7 +1189,7 @@ class MixingPool(Route):
             diseases = None,
             src = None,
             dst = None, # Same as src
-            beta = 0.2,
+            beta = 1.0,
             contacts = ss.poisson(1.0),
         )
         self.update_pars(pars, **kwargs)


### PR DESCRIPTION
The previous default value of 0.2 was useful for the previous configuration in which the MixingPool beta was used directly in transmission. Now, that the MixingPool beta is a multiplier on the disease beta, the default value should be 1.0.

### Description


### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released