### PR TITLE
Display result name if result label is None

### DIFF
--- a/starsim/sim.py
+++ b/starsim/sim.py
@@ -632,7 +632,7 @@ class Sim(ss.Base):
                 if show_module == -1:
                     label = res.full_label.replace(':', '\n')
                 elif len(res.full_label) > show_module:
-                    label = res.label
+                    label = sc.ifelse(res.label, res.name)
                 else:
                     label = res.full_label
 


### PR DESCRIPTION
### Description
If full_label is too long to display (i.e. len(res.full_label) > show_module) and res.label is None, display res.name. This mirrors the behaviour of Result.full_label(), and avoids displaying blank plot titles for results that have not been assigned a label.

### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released
^^^Very minor update, no new docstrings, tests or versions needed.