### PR TITLE
Allow indexing Arr instances with boolean arrays

### DIFF
--- a/starsim/arrays.py
+++ b/starsim/arrays.py
@@ -220,6 +220,8 @@ class Arr(BaseArr):
             return uids()
         elif isinstance(key, np.ndarray) and ss.options.reticulate: # TODO: fix ss.uids
             return key.astype(int)
+        elif isinstance(key, np.ndarray) and key.dtype == bool:
+            return self.auids[key]
         else:
             errormsg = f'Indexing an Arr ({self.name}) by ({key}) is ambiguous or not supported. Use ss.uids() instead, or index Arr.raw or Arr.values.'
             raise Exception(errormsg)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -110,6 +110,7 @@ def test_arrs():
     assert not np.all(s2.people.alive.raw), 'Some agents should not be alive when indexed like this'
     assert np.array_equal(~s1.people.female, s1.people.male), 'Definition of men does not match'
     assert isinstance(s1.people.age < 5, ss.BoolArr), 'Performing logical operations should return a BoolArr'
+    assert np.array_equal(s1.people.age[s1.people.age < 5],s1.people.age[s1.people.age.values < 5])
 
     o.s1 = s1
     o.s2 = s2


### PR DESCRIPTION
Support indexing using boolean arrays the same size as `auids` (so that logical operations on `.values` can be used directly again to index other `Arr` instances)