### PR TITLE
replace sims with run versions

### DIFF
--- a/starsim/calibration.py
+++ b/starsim/calibration.py
@@ -313,6 +313,7 @@ class Calibration(sc.prettyobj):
 
         msim = ss.MultiSim(self.before_msim.sims + self.after_msim.sims)
         msim.run()
+        self.before_msim, self.after_msim = msim.sims
 
         self.before_fits = self.eval_fn(self.before_msim, **self.eval_kw)
         self.after_fits = self.eval_fn(self.after_msim, **self.eval_kw)


### PR DESCRIPTION
### Description
Minor edit to check_calib since the old version wasn't working for me. @daniel-klein I don't think this will work for calibrations that have been run for multiple seeds, but before I try to fix this, just wondering whether the previous version was working for you? 



### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released