### PR TITLE
Speed up time.py slightly

### DIFF
--- a/starsim/time.py
+++ b/starsim/time.py
@@ -1291,6 +1291,14 @@ class Time:
             if self.is_absolute != sim.t.is_absolute:
                 raise Exception('Cannot mix absolute/relative times across modules')
 
+        if sim.t.initialized and \
+                all([type(getattr(self, key)) == type(getattr(sim.t, key)) for key in ('start', 'stop', 'dt')]) and \
+                all([getattr(self, key) == getattr(sim.t, key) for key in ('start', 'stop', 'dt')]):
+            self._yearvec = sc.dcp(sim.t._yearvec)
+            self._tvec    = sc.cp(sim.t._tvec)  # ss.Dates are immutable so only need shallow copy
+            self.initialized = True
+            return self
+
         # We need to populate both the tvec (using dates) and the yearvec (using years). However, we
         # need to decide which of these quantities to prioritise considering that the calendar dates
         # don't convert consistently into fractional years due to varying month/year lengths. We will

--- a/starsim/time.py
+++ b/starsim/time.py
@@ -115,7 +115,7 @@ class date(pd.Timestamp):
         else:
             year_start = pd.Timestamp(year=int(year), month=1, day=1)
             year_end = pd.Timestamp(year=int(year) + 1, month=1, day=1)
-            return cls(year_start + year % 1 * (year_end - year_start))
+            return cls._reset_class(year_start + year % 1 * (year_end - year_start))
 
     def to_year(self):
         """

--- a/starsim/time.py
+++ b/starsim/time.py
@@ -1291,7 +1291,7 @@ class Time:
             if self.is_absolute != sim.t.is_absolute:
                 raise Exception('Cannot mix absolute/relative times across modules')
 
-        if sim.t.initialized and \
+        if sim is not None and sim.t.initialized and \
                 all([type(getattr(self, key)) == type(getattr(sim.t, key)) for key in ('start', 'stop', 'dt')]) and \
                 all([getattr(self, key) == getattr(sim.t, key) for key in ('start', 'stop', 'dt')]):
             self._yearvec = sc.dcp(sim.t._yearvec)


### PR DESCRIPTION
### Description
A couple speed ups:
They rely on the fact that `pd.Timestamp` is immutable, and we can change from a `pd.Timestamp` to a `ss.date` by calling `ss.date._reset_class(timestamp)`. This means when we create a pd.Timestamp in the functions `ss.date.from_year()` and `ss.date.__add__()` we don't need to copy the `pd.Timestamp` we get (which would happen in `ss.date.__new__()` ) - we only need to convert it from `pd.Timestamp` into a `ss.date` .

The other change is to not re-create the `ss.Time._yearvec` and `ss.Time._tvec` of each module if it is the same `start, stop, dt` as the `sim.t` - we can just create a copy. I guess this could break if the `sim.t` was initialized - then any of the `sim.t.start, sim.t.stop, sim.t.dt, sim.t._yearvec, sim.t._tvec` were then manually changed without reinitializing, then the module `time` objects were initialized, but that is not really an intended use.

### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released