### PR TITLE
Add official uv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ cd example
 uv add starsim
 ```
 
+To run a Starsim script with uv:
+```sh
+uv run python your_script.py
+```
+
+For development with optional dependencies:
+```sh
+uv add starsim[dev]
+```
+
 Starsim can also be installed locally. To do this, clone first this repository, then run:
 ```sh
 pip install -e .

--- a/llms.txt
+++ b/llms.txt
@@ -28,10 +28,10 @@ The main simulation loop is orchestrated by `starsim/loop.py`, while parameter m
 cd tests && ./run_tests
 
 # Run specific test file
-pytest test_sim.py
+cd tests && pytest test_sim.py
 
 # Run tests with coverage
-./check_coverage
+cd tests && ./check_coverage
 ```
 
 ### Code Quality
@@ -61,6 +61,10 @@ pip install -e .
 
 # With dev dependencies
 pip install -e .[dev]
+
+# Using uv for faster installs
+uv add starsim
+uv add starsim[dev]  # With dev dependencies
 ```
 
 ## Project Structure
@@ -100,10 +104,28 @@ Pre-implemented disease models including HIV, syphilis, gonorrhea, cholera, Ebol
 - Documentation built with Quarto and executed via Jupyter
 - Random number generation is centralized and uses Numba for performance
 
+## Module Architecture
+
+The framework uses a modular architecture where all components inherit from base classes:
+
+- **Base class hierarchy**: All modules inherit from `ss.Base` → `ss.Module` (defined in `modules.py`)
+- **Module types**: Networks, Demographics, Diseases, Interventions, Analyzers, Connectors
+- **Module registration**: Modules are automatically discovered and registered via the `find_modules()` function
+- **Integration loop**: The `Loop` class (in `loop.py`) orchestrates module execution during simulation
+- **State management**: People and network states are managed through specialized array classes (`arrays.py`)
+
+## Key Dependencies
+
+- **Sciris**: Core utility library for data structures, plotting, and utilities
+- **Numba**: Used for performance-critical code sections and random number generation
+- **NetworkX**: Network analysis and manipulation
+- **Pandas/NumPy**: Data manipulation and numerical operations
+- **Matplotlib/Seaborn**: Plotting and visualization
+
 ## Important Notes
 
 - Follow the style guide here: https://github.com/starsimhub/styleguide/blob/main/README.rst
-- Use built-in Starsim plotting commands if possible, only falling back to Matplotlib if necesary
+- Use built-in Starsim plotting commands if possible, only falling back to Matplotlib if necessary
 - Use Sciris where possible to shorten commands
 - When creating a multiline dictionary, put a space around the equals for arguments (as if it were a class)
 - Set `SCIRIS_BACKEND='agg'` environment variable when running tests to prevent figure display

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "numpy>=1.24.0",
     "pandas>=2.0.0",
     "sciris>=3.2.2",
-    "numba",
+    "numba>=0.57.0",
     "scipy",
     "networkx",
     "matplotlib",


### PR DESCRIPTION
## Summary

Closes #907

- Fixed numba dependency version requirement to `>=0.57.0` (resolves #902)
- Enhanced README with practical uv usage examples including `uv run` and dev dependencies
- Updated CLAUDE.md with uv installation instructions
- Tested uv installation works correctly with all dependencies

## Test plan

- [x] Test basic uv installation: `uv add starsim`
- [x] Test uv can run starsim: `uv run python -c "import starsim as ss; ss.demo()"`
- [x] Verify numba >= 0.57.0 gets installed correctly
- [x] Confirm no dependency resolution conflicts