### PR TITLE
Add missing argument

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ What's new
 All notable changes to the codebase are documented in this file. Changes that may result in differences in model output, or are required in order to run an old parameter set with the current version, are flagged with the term "Regression information".
 
 
+Version 2.3.2 (2025-07-16)
+---------------------------
+- Fix argument passing in ``Infection.infect``. This will be the final Starsim v2.x release.
+- *GitHub info*: PR `1008 <https://github.com/starsimhub/starsim/pull/1008>`_
+
+
 Version 2.3.1 (2025-02-25)
 ---------------------------
 - Updated ``ss.Sim.shrink()`` to remove additional objects, resulting in a smaller sim size.

--- a/starsim/disease.py
+++ b/starsim/disease.py
@@ -313,7 +313,7 @@ class Infection(Disease):
                 p2p1b1 = [edges.p2, edges.p1, betamap[nk][1]] # Person 2, person 1, beta 1
                 for src, trg, beta in [p1p2b0, p2p1b1]:
                     if beta: # Skip networks with no transmission
-                        beta_per_dt = route.net_beta(disease_beta=beta) # Compute beta for this network and timestep
+                        beta_per_dt = route.net_beta(disease_beta=beta, disease=self) # Compute beta for this network and timestep
                         randvals = self.trans_rng.rvs(src, trg) # Generate a new random number based on the two other random numbers
                         args = (src, trg, rel_trans, rel_sus, beta_per_dt, randvals) # Set up the arguments to calculate transmission
                         target_uids, source_uids = self.compute_transmission(*args) # Actually calculate it

--- a/starsim/version.py
+++ b/starsim/version.py
@@ -4,6 +4,6 @@ Version and license information.
 
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__ = '2.3.1'
-__versiondate__ = '2025-02-25'
+__version__ = '2.3.2'
+__versiondate__ = '2025-07-16'
 __license__ = f'Starsim {__version__} ({__versiondate__}) — © 2023-2025 by IDM'


### PR DESCRIPTION
### Description

`Infection.infect` isn't passing the optional `disease` argument to `route.net_beta` which causes a problem if the user inherits from `Infection` and then implements a network that requires the `disease` as part of it's `net_beta` implementation