### PR TITLE
Fix module name handling for Sim objects in Loop class

### DIFF
--- a/starsim/loop.py
+++ b/starsim/loop.py
@@ -49,7 +49,12 @@ class Loop:
         func_name = func.__name__
 
         # Get the name if it's defined, the class otherwise; these must match abs_tvecs
-        module = parent.name if isinstance(parent, ss.Module) else parent.__class__.__name__.lower()
+        if isinstance(parent, ss.Module):
+            module = parent.name
+        elif isinstance(parent, ss.Sim):
+            module = 'sim'
+        else:
+            module = parent.__class__.__name__.lower()
 
         # Create the row and append it to the function list
         row = dict(func_order=len(self.funcs), module=module, func_name=func_name, func=func)


### PR DESCRIPTION
Handle ss.Sim parent objects by using 'sim' as module name instead of falling back to the class name, ensuring proper module identification.