### PR TITLE
initialize age before female in people constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the codebase are documented in this file. Changes that may result in differences in model output, or are required in order to run an old parameter set with the current version, are flagged with the term "Regression information".
 
 
+## Version 3.0.3 (2025-10-07)
+- Swapped order of `age` and `female` states in People to allow `female` dist to use `age` state during population initialization.
+
 ## Version 3.0.2 (2025-08-25)
 - Additional minor updates following the v3 release.
 - Cleans up some of the logic for convertin rates to probabilities in the demographic modules

--- a/starsim/people.py
+++ b/starsim/people.py
@@ -63,8 +63,8 @@ class People:
         extra_states = sc.promotetolist(extra_states)
         states = [
             ss.BoolState('alive', default=True),  # Time index for death
+            ss.FloatArr('age', default=self.get_age_dist(age_data)),  # NaN until conceived
             ss.BoolState('female', default=ss.bernoulli(name='female', p=0.5)),
-            ss.FloatArr('age', default=self.get_age_dist(age_data)), # NaN until conceived
             ss.FloatArr('ti_dead'),  # Time index for death
             ss.FloatArr('ti_removed'),  # Time index for removal (e.g. emigration)
             ss.FloatArr('scale', default=1.0), # The scale factor for the agents (multiplied for making results)

--- a/starsim/version.py
+++ b/starsim/version.py
@@ -4,6 +4,6 @@ Version and license information.
 
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__ = '3.0.2'
-__versiondate__ = '2025-08-25'
+__version__ = '3.0.3'
+__versiondate__ = '2025-10-07'
 __license__ = f'Starsim {__version__} ({__versiondate__}) — © 2023-2025 by IDM'


### PR DESCRIPTION
### Description
Initial population structures might not only have varying populations by age, but also by sex. e.g., in a post-war scenario, the population of males might be lower than females for a given age bin. A feature that is currently missing is the ability to initialize the sex of the initial population based on age and sex.

One approach is to manually override the sex after initialization:
```
sim.init()
sim.people.female = ...
```
but there is no guarantee that this won't have unwanted side effects. Other modules could initialize their states based on the initial population's sex, and modifying the sex afterward would invalidate those values.

Another approach is to use a callback function for the bernoulli distribution p value, something like this:

```
def set_p_by_age(self, sim, uids):
    p = np.full(len(uids), fill_value=0.50)  # Default even probability male/female
    p[sim.people.age < 25 and sim.people.age >20] = 0.75  # 50% fewer males for ages > 20 and < 25.

    return p

ppl = ss.People(n_agents=n_agents, age_data=age_df)
ppl.female.default.pars.p = set_p_by_age

sim = ss.Sim(people=ppl, ...)
```
but this currently fails because the age state isn't initialized before the first callback call.

This can be fixed by swapping the order of the states in People.py such that age comes before female. It avoids the risk of side effects in the first option while still allowing age-sex structure in the initial population without altering the way sex is assigned to newborns. If the ratio of female to male births are expected to change during the sim, then p can be modified again as needed post-init.

Closes #1050 .

### Checklist
- [NA] Code commented & docstrings added
- [NA] New tests were needed and have been added
- [X] A new version number was needed & changelog has been updated
- [X] A new PyPI version needs to be released