### PR TITLE
Release to PyPI and update documentation upon tag creation

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -1,6 +1,10 @@
-name: Publish Starsim docs (manual)
+name: Publish Starsim docs
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -1,6 +1,10 @@
-name: Publish Starsim to PyPI (manual)
+name: Publish Starsim to PyPI
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
In addition to manual triggering, automatically publish to PyPI and deploy documentation when a tag (starting with `v`) is created  