### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,6 @@
 
 
 ### Checklist
-- [ ] Code commented & docstrings added
-- [ ] New tests were needed and have been added
-- [ ] A new version number was needed & changelog has been updated
-- [ ] A new PyPI version needs to be released
+- [ ] All new functions have a docstring and are appropriately commented
+- [ ] New tests were needed and have been added, or no tests required
+- [ ] Changelog has been updated, or there are no user-facing changes


### PR DESCRIPTION
Open for discussion, but the updated checklist proposed here means

- Any PR regardless of its contents would be expected to tick all of the boxes (whereas in the current/existing checklist, it is ambiguous whether a user should tick the box if something was not required, therefore not all PRs are ticking all the boxes and it's hard to tell if anything is missing)
- Version numbers are not expected to be changed in typical PRs which would be made against an `rc` branch (where the `rc` branch contains the new version number). This also helps to avoid conflicts in the version number as the version number is only updated once when the `rc` branch is merged into `main`
- The item for PyPI releases has been removed as we move towards a more continuous deployment workflow, the intention is that we should expected prompt release of PRs after they have been merged, so there is no need to note that a release is required