### PR TITLE
Fix typo in demographics module documentation

### DIFF
--- a/docs/user_guide/modules_demographics.ipynb
+++ b/docs/user_guide/modules_demographics.ipynb
@@ -140,7 +140,7 @@
     "    - Use `demographics=True` for default birth/death rates\n",
     "    - Use `birth_rate` and `death_rate` for custom constant rates\n",
     "    - Use `ss.Pregnancy()` for age-specific fertility, pregnancy modeling, and mother-to-child transmission\n",
-    "    - Demographics automatically enables aging; if you want to use aging without demographics, set `use_aging=True`"
+    "    - Demographics automatically enables aging; if you want to use demographics without ageing, set `use_aging=False`"
    ]
   },
   {


### PR DESCRIPTION
### Description
I don't think original reads right. This should be the case.
Not quoting since the change is in docs and not on code.
### Checklist
- [ ] Code commented & docstrings added
- [ ] New tests were needed and have been added
- [ ] A new version number was needed & changelog has been updated
- [ ] A new PyPI version needs to be released