### PR TITLE
Make copy compatible with None

### DIFF
--- a/starsim/calibration.py
+++ b/starsim/calibration.py
@@ -298,8 +298,8 @@ class Calibration(sc.prettyobj):
         for parname, spec in after_pars.items():
             spec['value'] = self.best_pars[parname] # Use best parameters from calibration
 
-        self.before_msim = self.build_fn(self.sim.copy(), calib_pars=before_pars, **self.build_kw)
-        self.after_msim = self.build_fn(self.sim.copy(), calib_pars=after_pars, **self.build_kw)
+        self.before_msim = self.build_fn(sc.dcp(self.sim), calib_pars=before_pars, **self.build_kw)
+        self.after_msim = self.build_fn(sc.dcp(self.sim), calib_pars=after_pars, **self.build_kw)
 
         fix_before = isinstance(self.before_msim, ss.Sim)
         fix_after = isinstance(self.after_msim, ss.Sim)


### PR DESCRIPTION
### Description

A possible workflow is for a user to define a calibration `build_fn` that actually creates a `Sim` from scratch, rather than modifying an existing `Sim` - e.g., this can be the easiest option when an analysis repository already contains a `make_sim` function. In that case, `Calibration.sim` can be `None`. However, `self.sim.copy()` then fails. This PR just switches the copying to be an explicit call to `sc.dcp()` that also handles `self.sim` being `None`

### Checklist
- [x] All new functions have a docstring and are appropriately commented
- [x] New tests were needed and have been added, or no tests required
- [x] Changelog has been updated, or there are no user-facing changes
