### PR TITLE
Fix ASFR annualization being overwritten by zeros

### DIFF
--- a/starsim/demographics.py
+++ b/starsim/demographics.py
@@ -1012,8 +1012,5 @@ class Pregnancy(Demographics):
         cs = np.cumsum(self.asfr, axis=1)
         asfr = np.zeros((n_bins, self.t.npts))
         asfr[:, tdim-1:] = cs[:, tdim-1:] - np.hstack([np.zeros((n_bins, 1)), cs[:, :-tdim]])
-        asfr = np.zeros((len(self.asfr_bins)-1, self.t.npts))
-        tdim = int(1/self.t.dt_year)
-        tdim = min(tdim, self.t.npts)
         self.asfr = asfr
         return


### PR DESCRIPTION
Remove duplicate `asfr = np.zeros(...)` and redundant `tdim` recomputation in Pregnancy.finalize() that overwrote the correctly computed rolling annual sum with an array of zeros.

### Description


### Checklist
- [ ] All new functions have a docstring and are appropriately commented
- [ ] New tests were needed and have been added, or no tests required
- [ ] Changelog has been updated, or there are no user-facing changes
