### PR TITLE
Fix EvolvingHouseholdDHSNet example network

### DIFF
--- a/starsim_examples/networks/dhs.py
+++ b/starsim_examples/networks/dhs.py
@@ -262,6 +262,6 @@ class EvolvingHouseholdDHSNet(HouseholdDHSNet):
             self.household_ids[partners] = new_cids
 
         # Only consider move out once per pregnancy
-        self.ti_move_out_check[potential_movers] = ppl.pregnancy.ti_postpartum[
+        self.ti_move_out_check[potential_movers] = ppl.pregnancy.ti_delivery[
             potential_movers]  # Update the time index for checking when to move out
         return


### PR DESCRIPTION
The Pregnancy module removed ti_postpartum in v3.1, use ti_delivery to reset household formation check time instead. Closes #1202 