### PR TITLE
fix to household net silently ignoring arguments

### DIFF
--- a/starsim/networks.py
+++ b/starsim/networks.py
@@ -1097,8 +1097,8 @@ class HouseholdNet(Network):
         sim.run()
         sim.plot()
     """
-    def __init__(self, pars=None, dhs_data=None, dynamic=True, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, pars=None, dhs_data=None, dynamic=True, prob_move_out=_, update_freq=_, **kwargs):
+        super().__init__()
         self.define_pars(
             prob_move_out = ss.bernoulli(p=0.7),
             update_freq = 1,
@@ -1110,7 +1110,7 @@ class HouseholdNet(Network):
         states = [ss.FloatArr('household_ids')]
         if self.dynamic:
             states += [
-                ss.BoolArr('fhoh', default='False'),
+                ss.BoolArr('fhoh', default=False),
                 ss.FloatArr('ti_move_out_check', default='-inf'),
             ]
         self.define_states(*states)


### PR DESCRIPTION
## Summary

Fixes #1221

`HouseholdNet.__init__` declared `prob_move_out` and `update_freq` as explicit keyword
arguments, which caused them to be bound to local variables instead of flowing through
`**kwargs`. As a result, `self.update_pars(pars, **kwargs)` never saw them and any
user-supplied values were silently discarded.

## Change

Remove `prob_move_out` and `update_freq` from the explicit signature so they fall through
to `**kwargs`, consistent with the convention used by other networks (e.g. `StaticNet`,
`RandomNet`).

```python
# Before
def __init__(self, pars=None, dhs_data=None, dynamic=True, prob_move_out=_, update_freq=_, **kwargs):

# After
def __init__(self, pars=None, dhs_data=None, dynamic=True, **kwargs):
