### PR TITLE
Updates to UID operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the codebase are documented in this file. Changes that may result in differences in model output, or are required in order to run an old parameter set with the current version, are flagged with the terms "Migration" or "Regression".
 
 
+## Version 3.3.1 (upcoming)
+- Added `+` and `+=` operators to `ss.uids` for concatenation (e.g. `a + b` is equivalent to `a.concat(b)`). Note that `+` preserves duplicates, unlike `|` which deduplicates.
+- Comparison operations on `ss.uids` (e.g. `a == b`) now correctly return a plain `np.ndarray` instead of a `uids` instance.
+- Scalar reductions on `ss.uids` (e.g. `x.max()`, `x.min()`) now return a plain Python `int`, consistent with element indexing (`x[0]`).
+- Numeric aggregation operations that are not meaningful for UID arrays (`sum()`, `mean()`, `std()`, `var()`, `prod()`, `cumsum()`, `cumprod()`) now raise `TypeError`.
+
+
 ## Version 3.3.0 (2026-03-27)
 - Made scalar time parameters behave more consistently by removing the ability to index them if they are scalars, and also having `np.iterable()` return `False` for such parameters
 - **Backwards-compatibility notes:** This change may cause simulation results to be numerically different, as it will cause distributions to use a more efficient sampling method for affected scalar parameters (in such cases, there is likely to be a performance increase)

--- a/starsim/arrays.py
+++ b/starsim/arrays.py
@@ -845,16 +845,16 @@ class uids(np.ndarray):
 
     The following operators are supported:
 
-    - ``+`` / ``+=``: concatenation — equivalent to `uids.concat()`. Duplicate entries are **preserved**.
+    - ``+`` / ``+=``: if the RHS is a ``uids``, concatenation (equivalent to `uids.concat()`); otherwise element-wise addition (e.g. ``uids([1,2]) + 1`` → ``uids([2,3])``). Concatenation preserves duplicates.
     - ``-`` / ``-=``: set difference — equivalent to `uids.remove()`. Duplicate entries in the original will also be removed (uses `np.setdiff1d` internally).
-    - ``|`` / ``|=``: union (unique elements from both arrays). Note that duplicate entries in the original are **removed** (use `+` instead to keep them)
+    - ``|`` / ``|=``: union (unique elements from both arrays). Note that duplicate entries in the original are **removed** (use ``+`` instead to keep them).
     - ``&`` / ``&=``: intersection
     - ``^`` / ``^=``: symmetric difference
 
-    Note: because `uids` is a subclass of `np.ndarray`, all in-place operators
-    (``+=``, ``-=``, etc.) must return a new array and rebind the variable, exactly
-    like in-place operations other immutable types. Any prior references to the original
-    array will still point to the old, unmodified object.
+    Note: because `uids` is a subclass of `np.ndarray`, set-like in-place operators
+    (``+=`` with a ``uids`` RHS, ``-=``, ``|=``, ``&=``, ``^=``) must return a new array and rebind
+    the variable. However, ``+=`` with a scalar or array RHS modifies the array in-place
+    and preserves ``id(self)``.
     """
     def __new__(cls, arr=None):
         if isinstance(arr, np.ndarray): # Shortcut to typical use case, where the input is an array
@@ -946,16 +946,25 @@ class uids(np.ndarray):
     def cumprod(self, *args, **kwargs): self._uid_op_error('cumprod')
 
     # Implement collection of operators
-    def __add__(self, other) : return self.concat(other)
+    def __add__(self, other):
+        if isinstance(other, uids):
+            return self.concat(other)   # concatenation: uids([1,2]) + uids([3]) → uids([1,2,3])
+        return super().__add__(other)   # element-wise:  uids([1,2]) + 1        → uids([2,3])
     def __and__(self, other) : return self.intersect(other)
     def __or__(self, other)  : return self.union(other)
     def __sub__(self, other) : return self.remove(other)
     def __xor__(self, other) : return self.xor(other)
     def __invert__(self)     : raise Exception(f"Cannot invert an instance of {self.__class__.__name__}. One possible cause is attempting `~x.uids` - use `x.false()` or `(~x).uids` instead")
 
-    # As the size of a set might change, in-place operations must necessarily return a copy
-    # that gets reassigned to the original variable (the same as inplace operations on an immutable type)
-    def __iadd__(self, other): return self.__add__(other)
+    # For set-like operations (uids RHS) the size changes, so in-place must return a new object
+    # and rebind the variable — same semantics as in-place operations on an immutable type.
+    # For scalar/array RHS (element-wise arithmetic) the size is unchanged, so we can modify
+    # in-place and preserve id(self).
+    def __iadd__(self, other):
+        if isinstance(other, uids):
+            return self.__add__(other)   # new object — size changes
+        np.add(self, other, out=self)    # in-place — size unchanged, id preserved
+        return self
     def __iand__(self, other): return self.__and__(other)
     def __ior__(self, other) : return self.__or__(other)
     def __isub__(self, other): return self.__sub__(other)

--- a/starsim/arrays.py
+++ b/starsim/arrays.py
@@ -842,6 +842,19 @@ class uids(np.ndarray):
     has additional methods `uids.concat()` (instance method), [`ss.uids.cat()`](`starsim.arrays.uids.cat`)
     (class method), `uids.remove()`, and `uids.intersect()` to simplify common
     UID operations.
+
+    The following operators are supported:
+
+    - ``+`` / ``+=``: concatenation — equivalent to `uids.concat()`. Duplicate entries are **preserved**.
+    - ``-`` / ``-=``: set difference — equivalent to `uids.remove()`. Duplicate entries in the original will also be removed (uses `np.setdiff1d` internally).
+    - ``|`` / ``|=``: union (unique elements from both arrays). Note that duplicate entries in the original are **removed** (use `+` instead to keep them)
+    - ``&`` / ``&=``: intersection
+    - ``^`` / ``^=``: symmetric difference
+
+    Note: because `uids` is a subclass of `np.ndarray`, all in-place operators
+    (``+=``, ``-=``, etc.) must return a new array and rebind the variable, exactly
+    like in-place operations other immutable types. Any prior references to the original
+    array will still point to the old, unmodified object.
     """
     def __new__(cls, arr=None):
         if isinstance(arr, np.ndarray): # Shortcut to typical use case, where the input is an array
@@ -893,7 +906,7 @@ class uids(np.ndarray):
         return np.setxor1d(self, other, **kw).view(self.__class__)
 
     def to_numpy(self):
-        """ Return a view as a standard NumPy array """
+        """ Return a view as maia standard NumPy array """
         return self.view(np.ndarray)
 
     def unique(self, return_index=False):
@@ -905,15 +918,44 @@ class uids(np.ndarray):
             arr = np.unique(self).view(self.__class__)
             return arr
 
+    def __array_wrap__(self, out_arr, context=None, return_scalar=False):
+        # Guard 1: non-integer dtype → return a plain ndarray.
+        # Example: `uids_a == uids_b` produces a bool array. A boolean uids should
+        # never exist — uids are integer indices only — and returning one would cause
+        # `~(a == b)` to hit our __invert__ guard instead of doing a normal bitwise NOT.
+        if out_arr.dtype.kind not in ('i', 'u'):
+            return out_arr.view(np.ndarray)
+        # Guard 2: scalar reductions → return a plain Python int.
+        # Example: `uids.max()` should behave like `uids[0]` (a bare integer), not
+        # return a 0-d uids whose subsequent use in arithmetic (e.g. `max + 1`) would
+        # incorrectly route through our __add__ concatenation operator.
+        if return_scalar:
+            return out_arr.item()
+        return super().__array_wrap__(out_arr, context, return_scalar)
+
+    def _uid_op_error(self, name):
+        msg = f'{name}() is not meaningful for {self.__class__.__name__}: UIDs are identifiers, not numeric values'
+        raise TypeError(msg)
+
+    def sum(self, *args, **kwargs):     self._uid_op_error('sum')
+    def mean(self, *args, **kwargs):    self._uid_op_error('mean')
+    def std(self, *args, **kwargs):     self._uid_op_error('std')
+    def var(self, *args, **kwargs):     self._uid_op_error('var')
+    def prod(self, *args, **kwargs):    self._uid_op_error('prod')
+    def cumsum(self, *args, **kwargs):  self._uid_op_error('cumsum')
+    def cumprod(self, *args, **kwargs): self._uid_op_error('cumprod')
+
     # Implement collection of operators
-    def __and__(self, other): return self.intersect(other)
-    def __or__(self, other) : return self.union(other)
-    def __sub__(self, other): return self.remove(other)
-    def __xor__(self, other): return self.xor(other)
-    def __invert__(self)    : raise Exception(f"Cannot invert an instance of {self.__class__.__name__}. One possible cause is attempting `~x.uids` - use `x.false()` or `(~x).uids` instead")
+    def __add__(self, other) : return self.concat(other)
+    def __and__(self, other) : return self.intersect(other)
+    def __or__(self, other)  : return self.union(other)
+    def __sub__(self, other) : return self.remove(other)
+    def __xor__(self, other) : return self.xor(other)
+    def __invert__(self)     : raise Exception(f"Cannot invert an instance of {self.__class__.__name__}. One possible cause is attempting `~x.uids` - use `x.false()` or `(~x).uids` instead")
 
     # As the size of a set might change, in-place operations must necessarily return a copy
     # that gets reassigned to the original variable (the same as inplace operations on an immutable type)
+    def __iadd__(self, other): return self.__add__(other)
     def __iand__(self, other): return self.__and__(other)
     def __ior__(self, other) : return self.__or__(other)
     def __isub__(self, other): return self.__sub__(other)

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -257,6 +257,92 @@ def test_arr_type_conversion():
     return dict(ab=ab, ba=ba, cd=cd, dc=dc)
 
 
+@sc.timer()
+def test_uids_operators():
+    sc.heading('Testing uids + and += operators')
+
+    a = ss.uids([1, 2, 3])
+    b = ss.uids([4, 5])
+
+    # __add__ returns a new uids with concatenated values
+    c = a + b
+    assert isinstance(c, ss.uids), '__add__ must return a uids instance'
+    assert list(c) == [1, 2, 3, 4, 5], '__add__ must concatenate values in order'
+
+    # __add__ does not modify the operands
+    assert list(a) == [1, 2, 3], '__add__ must not modify the left operand'
+    assert list(b) == [4, 5],    '__add__ must not modify the right operand'
+
+    # __add__ result is a distinct object
+    assert id(c) != id(a), '__add__ must return a new object'
+
+    # + with empty
+    assert list(a + ss.uids()) == [1, 2, 3], 'Concatenation with empty on right must return original values'
+    assert list(ss.uids() + a) == [1, 2, 3], 'Concatenation with empty on left must return original values'
+
+    # + accepts a plain ndarray on the RHS (same as concat)
+    c_np = a + np.array([4, 5])
+    assert isinstance(c_np, ss.uids), '__add__ with ndarray RHS must return a uids instance'
+    assert list(c_np) == [1, 2, 3, 4, 5], '__add__ with ndarray RHS must concatenate correctly'
+
+    # + preserves duplicates (unlike | which deduplicates)
+    dup = ss.uids([1, 2, 3])
+    assert list(a + dup) == [1, 2, 3, 1, 2, 3], '+ must preserve duplicate entries'
+    assert len(a | dup) == 3, '| must deduplicate'
+
+    # __iadd__ produces the same values as concat
+    x = ss.uids([10, 20])
+    y = ss.uids([30, 40])
+    via_concat = x.concat(y)
+    x += y
+    np.testing.assert_array_equal(x, via_concat), '+= must produce same result as concat'
+    assert isinstance(x, ss.uids), '+= must return a uids instance'
+
+    # += necessarily changes id (uids is a fixed-size ndarray subclass — cannot resize in-place)
+    a = ss.uids([1, 2, 3])
+    ref = a
+    original_id = id(a)
+    a += ss.uids([4, 5])
+    assert id(a) != original_id, '+= must rebind to a new object (cannot resize ndarray in-place)'
+    # The prior reference still points to the old, unmodified array
+    assert list(ref) == [1, 2, 3], 'Prior reference must still point to the original unmodified array'
+
+    return x
+
+
+@sc.timer()
+def test_uids_array_wrap():
+    sc.heading('Testing uids __array_wrap__ guards')
+
+    x = ss.uids([1, 2, 3])
+
+    # Scalar reductions must return plain Python ints, not uids
+    assert type(x.max()) is int, 'max() must return a plain Python int'
+    assert type(x.min()) is int, 'min() must return a plain Python int'
+    assert x.max() == 3, 'max() must return the correct value'
+    assert x.min() == 1, 'min() must return the correct value'
+
+    # Arithmetic on the returned scalar must not route through uids.__add__
+    assert x.max() + 1 == 4, 'max() + 1 must be plain integer arithmetic, not concatenation'
+
+    # Comparisons must return plain ndarray (not uids) to avoid hitting __invert__
+    eq = x == ss.uids([1, 2, 3])
+    assert type(eq) is np.ndarray, '== must return a plain ndarray, not uids'
+    assert eq.dtype == bool, '== result must have bool dtype'
+    assert np.all(~eq == False), '~ on the bool result of == must work normally'
+
+    # Nonsensical numeric reductions must raise TypeError — via instance method
+    for op in ('sum', 'mean', 'std', 'var', 'prod', 'cumsum', 'cumprod'):
+        with pytest.raises(TypeError):
+            getattr(x, op)()
+
+    # np.sum(x) also routes through x.sum() and must raise the same error
+    with pytest.raises(TypeError):
+        np.sum(x)
+
+    return x
+
+
 # %% Run as a script
 if __name__ == '__main__':
     do_plot = True
@@ -269,6 +355,8 @@ if __name__ == '__main__':
     sims  = test_arrs()
     arrs  = test_arr_inplace()
     vals  = test_arr_type_conversion()
+    uids  = test_uids_operators()
+    wrap  = test_uids_array_wrap()
 
     sc.toc(T)
     plt.show()

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -280,32 +280,43 @@ def test_uids_operators():
     assert list(a + ss.uids()) == [1, 2, 3], 'Concatenation with empty on right must return original values'
     assert list(ss.uids() + a) == [1, 2, 3], 'Concatenation with empty on left must return original values'
 
-    # + accepts a plain ndarray on the RHS (same as concat)
-    c_np = a + np.array([4, 5])
-    assert isinstance(c_np, ss.uids), '__add__ with ndarray RHS must return a uids instance'
-    assert list(c_np) == [1, 2, 3, 4, 5], '__add__ with ndarray RHS must concatenate correctly'
+    # + with a uids RHS concatenates; with a non-uids RHS does element-wise addition
+    assert list(a + ss.uids([4, 5])) == [1, 2, 3, 4, 5],    '+ with uids RHS must concatenate'
+    assert list(a + 10) == [11, 12, 13],                      '+ with scalar RHS must add element-wise'
+    assert list(a + np.array([10, 20, 30])) == [11, 22, 33],  '+ with ndarray RHS must add element-wise'
+    assert isinstance(a + 1, ss.uids), '+ with scalar RHS must return a uids'
 
-    # + preserves duplicates (unlike | which deduplicates)
+    # element-wise addition is commutative via __radd__
+    assert list(10 + a) == [11, 12, 13], 'scalar + uids must also do element-wise addition'
+    assert isinstance(10 + a, ss.uids),  'scalar + uids must return a uids'
+
+    # + with uids RHS preserves duplicates (unlike | which deduplicates)
     dup = ss.uids([1, 2, 3])
-    assert list(a + dup) == [1, 2, 3, 1, 2, 3], '+ must preserve duplicate entries'
+    assert list(a + dup) == [1, 2, 3, 1, 2, 3], '+ with uids RHS must preserve duplicate entries'
     assert len(a | dup) == 3, '| must deduplicate'
 
-    # __iadd__ produces the same values as concat
+    # __iadd__ with uids RHS concatenates and rebinds (size changes, id changes)
     x = ss.uids([10, 20])
     y = ss.uids([30, 40])
     via_concat = x.concat(y)
     x += y
-    np.testing.assert_array_equal(x, via_concat), '+= must produce same result as concat'
-    assert isinstance(x, ss.uids), '+= must return a uids instance'
+    assert list(x) == list(via_concat), '+= with uids RHS must produce same result as concat'
+    assert isinstance(x, ss.uids), '+= with uids RHS must return a uids instance'
 
-    # += necessarily changes id (uids is a fixed-size ndarray subclass — cannot resize in-place)
+    # __iadd__ with uids RHS changes id (size changes, cannot resize ndarray in-place)
     a = ss.uids([1, 2, 3])
     ref = a
     original_id = id(a)
     a += ss.uids([4, 5])
-    assert id(a) != original_id, '+= must rebind to a new object (cannot resize ndarray in-place)'
-    # The prior reference still points to the old, unmodified array
+    assert id(a) != original_id, '+= with uids RHS must rebind to a new object'
     assert list(ref) == [1, 2, 3], 'Prior reference must still point to the original unmodified array'
+
+    # __iadd__ with scalar RHS modifies in-place (size unchanged, id preserved)
+    a = ss.uids([1, 2, 3])
+    original_id = id(a)
+    a += 10
+    assert list(a) == [11, 12, 13], '+= with scalar RHS must add element-wise'
+    assert id(a) == original_id,    '+= with scalar RHS must preserve id (in-place modification)'
 
     return x
 


### PR DESCRIPTION
### Description

Currently the `+` operator actually adds the UIDs e.g., `ss.uids([1,2,3]) + ss.uids([4,5,6]) = ss.uids([5, 7, 9])` which is unlikely to be what a user intends. This PR changes `+` to act as a shortcut for concatenation and thus complement `|` for set unions. 

This PR also includes some minor tidying of `uids` functionality 

- It's intended that `uids()` always store integer UIDs, but comparison operations would previously return a `uids` instance of bools. In this PR operations like `a == b` now correctly return a plain `np.ndarray`
- Previously indexing operations are expected to return integers e.g., `x = ss.uids([1,2,3])`, `x[0]` returns the number `1`. But some operations like `x.max()` would instead return `uids(3)`. In this PR such operations now return bare integers the same as indexing
- Similarly, some operations like `sum()` or `mean()` don't really make sense for collections of UIDs, these now raise `TypeError` to help users catch if they accidentally perform such operations

### Checklist
- [x] All new functions have a docstring and are appropriately commented
- [x] New tests were needed and have been added, or no tests required
- [x] Changelog has been updated, or there are no user-facing changes
