### PR TITLE
Fix dynamic household births

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the codebase are documented in this file. Changes that may result in differences in model output, or are required in order to run an old parameter set with the current version, are flagged with the terms "Migration" or "Regression".
 
 
+## Version 3.3.3 (2026-04-08)
+- Fixed `HouseholdNet.add_births()` to assign household IDs exactly once at delivery, rather than using an age-window heuristic tied to `update_freq`. Newborns are now identified by having a parent, age >= 0, and no household ID yet assigned.
+- Moved HouseholdNet's `add_births()` call before the `update_freq` gate so it runs every timestep, ensuring correct behavior with any update frequency or when the network timestep exceeds gestation.
+- Fixed self-loops in household edge creation for newborns.
+- *GitHub info*: PR [TBD](https://github.com/starsimhub/starsim/pull/TBD)
+
+
 ## Version 3.3.2 (2026-04-04)
 - Added a `copy_sim` argument to `ss.MultiSim.run()` to handle large parallel runs of a single sim (e.g. `ss.MultiSim(sim, n_runs=100)`), where multiprocess pickling isn't guaranteed to implicitly copy the sim.
 - Removed (unused) `_locked` attribute from `ss.TimePar`.

--- a/starsim/networks.py
+++ b/starsim/networks.py
@@ -1188,40 +1188,48 @@ class HouseholdNet(Network):
         if not self.dynamic:
             return
 
+        self.add_births()
+
         if np.mod(self.ti, self.pars.update_freq):
             return
 
-        self.add_births()
         self.create_new_households()
         return
 
     def add_births(self):
         sim = self.sim
-        birth_uids = ss.uids((sim.people.age < self.pars.update_freq * self.sim.t.dt_year))
+        ppl = sim.people
+
+        # Find agents born during the sim (have a parent), already delivered
+        # (age >= 0), and not yet assigned to a household (household_ids is NaN).
+        # The isnan guard ensures each newborn is processed exactly once.
+        candidates = ss.uids(ppl.parent.notnan & (ppl.age >= 0))
+        if len(candidates) == 0:
+            return 0
+        birth_uids = candidates[np.isnan(self.household_ids[candidates])]
         if len(birth_uids) == 0:
             return 0
 
-        mat_uids = sim.people.parent[birth_uids]
-        keep = mat_uids != sim.people.parent.nan
-        birth_uids = birth_uids[keep]
-        mat_uids = mat_uids[keep]
-        if len(birth_uids) == 0:
-            return 0
+        mat_uids = ppl.parent[birth_uids]
+
+        # Assign household IDs before creating edges so the newborn is
+        # included when looking up household members
+        self.household_ids[birth_uids] = self.household_ids[mat_uids]
 
         p1 = []
         p2 = []
         for new_uid, mat_uid in zip(birth_uids, mat_uids):
             hh_contacts = ss.uids(self.household_ids == self.household_ids[mat_uid])
+            hh_contacts = hh_contacts[hh_contacts != new_uid]  # Exclude self-loops
             p1.append(hh_contacts)
             p2.append([new_uid] * len(hh_contacts))
 
-        p1 = ss.uids.concatenate(p1)
-        p2 = ss.uids.concatenate(p2)
+        if p1:
+            p1 = ss.uids.concatenate(p1)
+            p2 = ss.uids.concatenate(p2)
+            beta = np.ones(len(p1), dtype=ss.dtypes.float)
+            self.append(p1=p1, p2=p2, beta=beta)
 
-        beta = np.ones(len(p1), dtype=ss.dtypes.float)
-        self.append(p1=p1, p2=p2, beta=beta)
-
-        self.household_ids[birth_uids] = self.household_ids[mat_uids]
         return len(birth_uids)
 
     def create_new_households(self):

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -292,8 +292,16 @@ def test_dynamic_household():
     sim = ss.Sim(n_agents=medium, diseases='sis', networks=household, demographics=preg, copy_inputs=False)
     sim.run()
 
-    # Check that household_ids are assigned
-    assert np.all(np.isfinite(household.household_ids[:]))
+    # All delivered agents should have household IDs; undelivered embryos should not.
+    # Agents born in the sim with age >= dt have been through at least one full step
+    # after delivery, so add_births() must have assigned them a household ID.
+    # Agents with age < dt at the end may be undelivered embryos whose age crossed
+    # zero only due to the end-of-step aging in finish_step.
+    ppl = sim.people
+    hids = household.household_ids[:]
+    born_in_sim = ppl.parent.notnan
+    delivered = ~born_in_sim | (ppl.age >= sim.t.dt_year)
+    assert np.all(np.isfinite(hids[delivered.uids])), 'Some delivered agents are missing household IDs'
 
     return sim
 


### PR DESCRIPTION
Rework add_births() so that newborns receive a household ID exactly once when they are delivered (age >= 0 and parent set), rather than using an age-window heuristic tied to update_freq. Move add_births() before the update_freq gate so it runs every timestep, ensuring it works correctly with any update frequency or when the network timestep exceeds gestation.

Also fix self-loops, assign household IDs before creating edges, and update the test to account for undelivered embryos at end-of-sim.

### Description


### Checklist
- [ ] All new functions have a docstring and are appropriately commented
- [ ] New tests were needed and have been added, or no tests required
- [X] Changelog has been updated, or there are no user-facing changes
