### PR TITLE
Fix delivery scheduling bugs in RoutineDelivery and CampaignDelivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the codebase are documented in this file. Changes that may result in differences in model output, or are required in order to run an old parameter set with the current version, are flagged with the terms "Migration" or "Regression".
 
 
+## Version 3.3.4 (2026-05-21)
+- Fixed `ss.CampaignDelivery` failing to initialize on date-based timelines: `init_pre()` now compares against the float `sim.t.yearvec` instead of the date-typed `sim.timevec`, which caused `sc.findnearest` to crash because subtracting `ss.date` objects produces `datedur`.
+- Fixed `ss.CampaignDelivery` missing a `coverage_dist` placeholder in `__init__`, which caused `AttributeError` on the first delivery. This affected `ss.campaign_screening`, `ss.campaign_triage`, and `ss.campaign_vx`.
+- Fixed `ss.RoutineDelivery` off-by-one when `dt = 1`: `adj_factor` is now `0` (was `1`) for `dt >= 1`, so the intervention no longer runs for one extra year past `end_year`. The previous behavior also caused an `IndexError` when a per-year `prob` array was supplied.
+- Aligned `RoutineDelivery.yearvec` with `self.timepoints` by slicing `sim.t.yearvec` directly, ensuring `prob` from `sc.smoothinterp` always matches the timepoint length.
+- **Regression**: `ss.routine_screening`, `ss.routine_triage`, and `ss.routine_vx` with `dt = 1` will now stop one year earlier than before (at `end_year` rather than `end_year + 1`).
+- Added test coverage for `RoutineDelivery` and `CampaignDelivery` in `tests/test_interventions.py`.
+- *GitHub info*: PR [TBD](https://github.com/starsimhub/starsim/pull/TBD)
+
+
 ## Version 3.3.3 (2026-04-15)
 - Added `ss.parse_age_range()` and `ss.apply_age_range()` to parse age range specifications like `'[5, 10), [10, 15)'`.
 - Optimized `ss.RandomNet()` performance.

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,6 +4,7 @@ results
 _freeze/
 tutorials/.jupyter_cache/
 objects.json
+objects.inv
 
 # Ignore auto-generated API .qmd files
 /api/*.qmd

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -5,6 +5,9 @@ project:
   output-dir: _site
   title: "Starsim"
   execute-dir: file
+  resources:
+    - objects.json
+    - objects.inv
 
 website:
   title: "Starsim"

--- a/docs/_variables.yml
+++ b/docs/_variables.yml
@@ -1,2 +1,2 @@
-version: 3.3.3
-versiondate: '2026-04-15'
+version: 3.3.4
+versiondate: '2026-05-21'

--- a/docs/_variables.yml
+++ b/docs/_variables.yml
@@ -1,2 +1,2 @@
-version: 3.3.3
-versiondate: '2026-04-15'
+version: 3.3.4
+versiondate: 2026-04-XX

--- a/docs/clean_all
+++ b/docs/clean_all
@@ -26,6 +26,7 @@ rm -rvf user_guide/.ipynb_checkpoints/
 rm -rvf user_guide/.jupyter_cache/
 rm -rvf user_guide/.virtual_documents/
 rm -vf objects.json
+rm -vf objects.inv
 
 duration=$(( SECONDS - start ))
 echo "Cleaned after $duration seconds."

--- a/docs/quarto_utils.py
+++ b/docs/quarto_utils.py
@@ -89,6 +89,33 @@ def build_interlinks():
     return run('python -m quartodoc interlinks')
 
 
+@sc.timer('Build objects.inv')
+def build_objects_inv(json_path='objects.json', inv_path='objects.inv'):
+    """
+    Convert the quartodoc JSON inventory into a Sphinx-compatible objects.inv,
+    so other projects can resolve Starsim references via intersphinx.
+    """
+    import sphobjinv as soi
+    sc.heading('Building Sphinx objects.inv ...')
+    data = sc.loadjson(json_path)
+    inv = soi.Inventory()
+    inv.project = data.get('project', 'starsim')
+    inv.version = str(data.get('version', ss.__version__))
+    for item in data['items']:
+        inv.objects.append(soi.DataObjStr(
+            name=item['name'],
+            domain=item['domain'],
+            role=item['role'],
+            priority=str(item.get('priority', '1')),
+            uri=item['uri'],
+            dispname=item.get('dispname', '-') or '-',
+        ))
+    with open(inv_path, 'wb') as f:
+        f.write(soi.compress(inv.data_file()))
+    print(f'  Wrote {len(inv.objects)} entries to {inv_path}')
+    return
+
+
 def qmd2py(qmd_path, py_path=None, keep_text=True):
     """
     Convert a .qmd file to a .py file by extracting Python code cells.
@@ -287,6 +314,7 @@ if __name__ == '__main__':
         build_api_docs()
         customize_aliases()
         build_interlinks()
+        build_objects_inv()
 
     elif 'post' in sys.argv:
         clean_outputs()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 quartodoc
+sphobjinv
 jupyter
 jupyter-cache
 jupytext

--- a/starsim/interventions.py
+++ b/starsim/interventions.py
@@ -114,16 +114,18 @@ class RoutineDelivery(Intervention):
             errormsg = 'Years must be within simulation start and end dates.'
             raise ValueError(errormsg)
 
-        # Adjustment to get the right end point
+        # Number of sub-year sim timesteps to include past end_year so the intervention
+        # covers the full end_year. For dt=1 this is 0; for dt=0.5 it's 1; for dt=0.1 it's 9.
         dt = sim.t.dt.years if isinstance(sim.t.dt, ss.dur) else sim.t.dt # TODO: need to eventually replace with own timestep, but not initialized yet since super().init_pre() hasn't been called
-        adj_factor = int(1/dt) - 1 if dt < 1 else 1
+        adj_factor = int(round(1/dt)) - 1 if dt < 1 else 0
 
-        # Determine the timepoints at which the intervention will be applied
+        # Determine the timepoints at which the intervention will be applied.
+        # self.yearvec is sliced from sim.t.yearvec so it stays length-aligned with self.timepoints.
         self.start_point = sc.findfirst(yearvec, start_year)
         self.end_point   = sc.findfirst(yearvec, end_year) + adj_factor
         self.years       = sc.inclusiverange(start_year, end_year)
         self.timepoints  = sc.inclusiverange(self.start_point, self.end_point)
-        self.yearvec     = np.arange(start_year, end_year + adj_factor, dt) # TODO: integrate with self.t
+        self.yearvec     = yearvec[self.start_point:self.end_point + 1]
 
         # Get the probability input into a format compatible with timepoints
         if len(self.years) != len(self.prob):
@@ -151,13 +153,16 @@ class CampaignDelivery(Intervention):
         self.years = sc.promotetoarray(years)
         self.interpolate = True if interpolate is None else interpolate
         self.prob = sc.promotetoarray(prob)
+        self.coverage_dist = ss.bernoulli(p=0)  # Placeholder - matches RoutineDelivery
         return
 
     def init_pre(self, sim):
         super().init_pre(sim)
 
-        # Decide whether to apply the intervention at every timepoint throughout the year, or just once.
-        self.timepoints = sc.findnearest(sim.timevec, self.years)
+        # Compare against the float yearvec, since sim.timevec may contain ss.date objects
+        # whose subtraction yields datedur (which sc.findnearest's np.argmin can't process).
+        years_float = np.array([y.years if hasattr(y, 'years') else float(y) for y in self.years])
+        self.timepoints = sc.findnearest(sim.t.yearvec, years_float)
 
         if len(self.prob) == 1:
             self.prob = np.array([self.prob[0]] * len(self.timepoints))

--- a/starsim/interventions.py
+++ b/starsim/interventions.py
@@ -153,7 +153,7 @@ class CampaignDelivery(Intervention):
         self.years = sc.promotetoarray(years)
         self.interpolate = True if interpolate is None else interpolate
         self.prob = sc.promotetoarray(prob)
-        self.coverage_dist = ss.bernoulli(p=0)  # Placeholder - matches RoutineDelivery
+        self.coverage_dist = ss.bernoulli(p=0)
         return
 
     def init_pre(self, sim):

--- a/starsim/interventions.py
+++ b/starsim/interventions.py
@@ -107,8 +107,8 @@ class RoutineDelivery(Intervention):
         # More validation
         # TODO: Refactor to be more agnostic about the types - leverage just doing direct comparisons and don't privilege year units
         yearvec = sim.t.yearvec
-        start_year = self.start_year.years if hasattr(self.start_year, 'years') else self.start_year
-        end_year = self.end_year.years if hasattr(self.end_year, 'years') else self.end_year
+        start_year = self.start_year.years if isinstance(self.start_year, ss.TimePar) else self.start_year
+        end_year = self.end_year.years if isinstance(self.end_year, ss.TimePar) else self.end_year
 
         if not(any(np.isclose(start_year, yearvec)) and any(np.isclose(end_year, yearvec))):
             errormsg = 'Years must be within simulation start and end dates.'
@@ -161,7 +161,7 @@ class CampaignDelivery(Intervention):
 
         # Compare against the float yearvec, since sim.timevec may contain ss.date objects
         # whose subtraction yields datedur (which sc.findnearest's np.argmin can't process).
-        years_float = np.array([y.years if hasattr(y, 'years') else float(y) for y in self.years])
+        years_float = np.array([y.years if isinstance(y, ss.TimePar) else float(y) for y in self.years]) # TODO: handle array timepars natively; skip if already an array
         self.timepoints = sc.findnearest(sim.t.yearvec, years_float)
 
         if len(self.prob) == 1:

--- a/starsim/version.py
+++ b/starsim/version.py
@@ -2,6 +2,6 @@
 Version and license information.
 """
 
-__version__ = '3.3.3'
-__versiondate__ = '2026-04-15'
+__version__ = '3.3.4'
+__versiondate__ = '2026-05-21'
 __license__ = f'Starsim {__version__} ({__versiondate__}) — © 2023-2026 by the Gates Foundation / Starsim Development Team'

--- a/tests/test_interventions.py
+++ b/tests/test_interventions.py
@@ -4,6 +4,32 @@ Run tests of vaccines and products
 import sciris as sc
 import numpy as np
 import starsim as ss
+import pytest
+
+
+def make_delivery_pars(n_agents=2_000, start=2000, stop=2020):
+    """ Lightweight SIS sim params shared across delivery tests """
+    return sc.objdict(
+        n_agents = n_agents,
+        start    = start,
+        stop     = stop,
+        diseases = 'sis',
+        networks = 'random',
+    )
+
+
+def make_dx():
+    """ Minimal diagnostic product used by delivery tests """
+    dx_data = sc.dataframe(
+        columns = ['disease', 'state', 'result', 'probability'],
+        data = [
+            ['sis', 'susceptible', 'positive', 0.01],
+            ['sis', 'susceptible', 'negative', 0.99],
+            ['sis', 'infected',    'positive', 0.95],
+            ['sis', 'infected',    'negative', 0.05],
+        ],
+    )
+    return ss.Dx(df=dx_data)
 
 
 def run_sir_vaccine(efficacy, leaky=True):
@@ -196,6 +222,157 @@ def test_two_products():
 
 
 
+@sc.timer()
+def test_routine_delivery_window():
+    """ RoutineDelivery should only deliver between start_year and end_year """
+    sc.heading('Testing RoutineDelivery start/end window...')
+
+    pars = make_delivery_pars(start=2000, stop=2020)
+    start_year, end_year = 2008, 2012
+    screening = ss.routine_screening(
+        product    = make_dx(),
+        prob       = 1.0,
+        start_year = start_year,
+        end_year   = end_year,
+    )
+    sim = ss.Sim(pars, interventions=screening).run()
+
+    n_screened = sim.results.routine_screening.n_screened
+    years      = sim.t.yearvec
+    pre        = years < start_year
+    post       = years > end_year
+
+    assert n_screened[pre].sum() == 0, \
+        f'Expected zero screenings before {start_year}, got {n_screened[pre].sum()}'
+    assert n_screened[post].sum() == 0, \
+        f'Expected zero screenings after {end_year}, got {n_screened[post].sum()}'
+    in_window = (years >= start_year) & (years <= end_year)
+    assert n_screened[in_window].sum() > 0, \
+        f'Expected nonzero screenings inside [{start_year}, {end_year}]'
+
+    return sim
+
+
+@sc.timer()
+def test_routine_delivery_prob_array():
+    """ RoutineDelivery should accept a per-year prob array matching the year window """
+    sc.heading('Testing RoutineDelivery prob-array scaling...')
+
+    pars = make_delivery_pars(start=2000, stop=2020)
+    years = np.arange(2005, 2016)               # 11 entries: 2005..2015
+    probs = np.linspace(0.05, 0.95, len(years)) # matching ramp 0.05 -> 0.95
+    screening = ss.routine_screening(
+        product = make_dx(),
+        prob    = probs,
+        years   = years,
+    )
+    sim = ss.Sim(pars, interventions=screening).run()
+
+    n_screened = sim.results.routine_screening.n_screened
+    yearvec    = sim.t.yearvec
+    early_mask = (yearvec >= 2005) & (yearvec <= 2007)
+    late_mask  = (yearvec >= 2013) & (yearvec <= 2015)
+    early_mean = n_screened[early_mask].mean()
+    late_mean  = n_screened[late_mask].mean()
+
+    assert late_mean > early_mean, \
+        f'Expected screening to scale up with prob array; got early={early_mean}, late={late_mean}'
+    # Late prob is ~19x early prob; require at least 3x to allow stochastic slack
+    assert late_mean > 3 * early_mean, \
+        f'Expected late screening >> early screening; got early={early_mean}, late={late_mean}'
+
+    return sim
+
+
+@sc.timer()
+def test_routine_delivery_default_years():
+    """ Omitting start/end_year should default to sim start/stop """
+    sc.heading('Testing RoutineDelivery default year handling...')
+
+    pars = make_delivery_pars(start=2010, stop=2014)
+    screening = ss.routine_screening(product=make_dx(), prob=0.5)
+    sim = ss.Sim(pars, interventions=screening).run()
+
+    n_screened = sim.results.routine_screening.n_screened
+    assert n_screened.sum() > 0, 'Expected screening to occur when no window specified'
+
+    return sim
+
+
+@sc.timer()
+def test_campaign_delivery_single_year():
+    """ CampaignDelivery should only deliver at the specified year """
+    sc.heading('Testing CampaignDelivery single year...')
+
+    pars = make_delivery_pars(start=2000, stop=2020)
+    campaign_year = 2010
+    screening = ss.campaign_screening(
+        product = make_dx(),
+        prob    = 0.5,
+        years   = campaign_year,
+    )
+    sim = ss.Sim(pars, interventions=screening).run()
+
+    n_screened = sim.results.campaign_screening.n_screened
+    yearvec    = sim.t.yearvec
+    on_year    = np.isclose(yearvec, campaign_year)
+    off_year   = ~on_year
+
+    assert n_screened[on_year].sum() > 0, \
+        f'Expected screenings on {campaign_year}, got 0'
+    assert n_screened[off_year].sum() == 0, \
+        f'Expected no screenings off-year, got {n_screened[off_year].sum()}'
+
+    return sim
+
+
+@sc.timer()
+def test_campaign_delivery_multi_year():
+    """ CampaignDelivery should deliver at each specified year and nowhere else """
+    sc.heading('Testing CampaignDelivery multi year...')
+
+    pars = make_delivery_pars(start=2000, stop=2020)
+    campaign_years = [2005, 2010, 2015]
+    probs = [0.3, 0.5, 0.7]
+    screening = ss.campaign_screening(
+        product = make_dx(),
+        prob    = probs,
+        years   = campaign_years,
+    )
+    sim = ss.Sim(pars, interventions=screening).run()
+
+    n_screened = sim.results.campaign_screening.n_screened
+    yearvec    = sim.t.yearvec
+    on_mask    = np.zeros_like(yearvec, dtype=bool)
+    for y in campaign_years:
+        on_mask |= np.isclose(yearvec, y)
+
+    assert n_screened[~on_mask].sum() == 0, \
+        f'Expected no screenings outside campaign years, got {n_screened[~on_mask].sum()}'
+    for y in campaign_years:
+        n_y = n_screened[np.isclose(yearvec, y)].sum()
+        assert n_y > 0, f'Expected screenings in {y}, got {n_y}'
+
+    return sim
+
+
+@sc.timer()
+def test_campaign_delivery_prob_length_mismatch():
+    """ CampaignDelivery should reject prob/years length mismatch """
+    sc.heading('Testing CampaignDelivery prob/years length validation...')
+
+    pars = make_delivery_pars(start=2000, stop=2020)
+    screening = ss.campaign_screening(
+        product = make_dx(),
+        prob    = [0.1, 0.2],  # length 2, but 3 years
+        years   = [2005, 2010, 2015],
+    )
+    with pytest.raises(ValueError):
+        ss.Sim(pars, interventions=screening).init()
+
+    return screening
+
+
 if __name__ == '__main__':
     T = sc.timer()
     do_plot = True
@@ -203,6 +380,13 @@ if __name__ == '__main__':
     leaky  = test_sir_vaccine_leaky()
     a_or_n = test_sir_vaccine_all_or_nothing()
     prod   = test_products(do_plot=do_plot)
-    prod2   = test_two_products()
+    prod2  = test_two_products()
+
+    s_win    = test_routine_delivery_window()
+    s_parr   = test_routine_delivery_prob_array()
+    s_def    = test_routine_delivery_default_years()
+    s_csing  = test_campaign_delivery_single_year()
+    s_cmulti = test_campaign_delivery_multi_year()
+    s_cmm    = test_campaign_delivery_prob_length_mismatch()
 
     T.toc()


### PR DESCRIPTION
Working with the Delivery classes in HPVsim revealed some bugs that need to be addressed. If tests are too heavy we could trim them down.

### Description

CampaignDelivery
- init_pre: compare against sim.t.yearvec (float) instead of sim.timevec, which may contain ss.date objects whose subtraction yields datedur and breaks sc.findnearest's np.argmin.
- __init__: initialize self.coverage_dist (was missing, parallel to RoutineDelivery), so BaseTest.deliver does not AttributeError on the first delivery.

RoutineDelivery
- adj_factor: use 0 (not 1) when dt >= 1. The previous "else 1" extended timepoints one step past end_year for dt=1, which both delivered an extra year past end_year and caused an IndexError into the prob array.
- self.yearvec: slice from sim.t.yearvec aligned with timepoint indices so smoothinterp produces a prob array length-matched to timepoints.

Tests
- New: routine_delivery_window, routine_delivery_prob_array, routine_delivery_default_years, campaign_delivery_single_year, campaign_delivery_multi_year, campaign_delivery_prob_length_mismatch.

Closes #1340. 

### Checklist
- [X] All new functions have a docstring and are appropriately commented
- [X] New tests were needed and have been added, or no tests required
- [X] Changelog has been updated, or there are no user-facing changes
