### PR TITLE
Clear caches

### DIFF
--- a/starsim/distributions.py
+++ b/starsim/distributions.py
@@ -163,6 +163,13 @@ class Dists(sc.prettyobj):
             out += dist.reset()
         return out
 
+    def clear_run_caches(self):
+        """ Clear rebuildable per-run caches from each managed distribution """
+        if self.dists is not None:
+            for dist in self.dists.values():
+                dist.clear_run_cache()
+        return
+
     def copy_to_module(self, module):
         """ Copy the Sim's Dists object to the specified module """
         matches = {key:dist for key,dist in self.dists.items() if id(dist.module) == id(module)} # Find which dists belong to this module
@@ -975,9 +982,19 @@ class Dist:
         )
         return out
 
+    def clear_run_cache(self):
+        """ Clear transient callable/draw caches without unlinking the distribution """
+        self._callable_args = None
+        self._callable_keys = None
+        self._uids = None
+        self._slots = None
+        self._n = None
+        self._size = None
+        return
+
     def shrink(self):
         """ Shrink the size of the module for saving to disk """
-        to_shrink = ['slots', '_slots', 'module', 'sim', '_n', '_uids', '_callable_args']
+        to_shrink = ['slots', '_slots', 'module', 'sim', '_n', '_uids', '_callable_args', '_callable_keys']
         ss.shrink(self, to_shrink)
         self.history = [] # Clear history explicitly rather than shrinking it
         return

--- a/starsim/loop.py
+++ b/starsim/loop.py
@@ -2,12 +2,25 @@
 Parent class for the integration loop.
 """
 import time
+from dataclasses import dataclass
+from typing import Callable
 import numpy as np
 import pandas as pd
 import sciris as sc
 import starsim as ss
 import matplotlib.pyplot as plt
 
+
+@dataclass
+class LoopEntry:
+    """ One executable event in the integration loop """
+    time: object
+    ti: int
+    func_order: int | None
+    func: Callable
+    label: str
+    module: str | None
+    func_name: str
 
 
 #%% Loop class
@@ -46,6 +59,7 @@ class Loop:
         self.func_list = []
         self.abs_tvecs = None
         self.plan = None
+        self.insertions = []
         self.index = 0 # The next function to execute
         self.cpu_time = [] # Store the CPU time of execution of each function
         self.df = None # User-friendly version of the plan
@@ -58,7 +72,6 @@ class Loop:
         self.collect_funcs()
         self.collect_abs_tvecs()
         self.make_plan()
-        self.to_df()
         self.initialized = True
         return
 
@@ -190,33 +203,37 @@ class Loop:
         raw = []
         for func_row in self.funcs:
             for t in self.abs_tvecs[func_row['module']]:
-                row = func_row.copy()
-                row['time'] = t # Add time column
-                raw.append(row)
-
-        # Turn it into a dataframe
-        self.plan = sc.dataframe(raw)
+                module = func_row['module']
+                func_name = func_row['func_name']
+                raw.append(LoopEntry(
+                    time = t,
+                    ti = 0,
+                    func_order = func_row['func_order'],
+                    func = func_row['func'],
+                    label = f'{module}.{func_name}',
+                    module = module,
+                    func_name = func_name,
+                ))
 
         # Sort it by step_order, a combination of time and function order
-        self.plan['ti'] = 0
-        self.plan['label'] = self.plan.module + '.' + self.plan.func_name
-        col_order = ['time', 'ti', 'func_order', 'func', 'label', 'module', 'func_name'] # Func in the middle to hide it
-        self.plan = self.plan.sort_values(['time','func_order']).reset_index(drop=True)[col_order]
+        self.plan = sorted(raw, key=lambda entry: (entry.time, entry.func_order))
 
         # Calculate the sim time index (ti)
         start_step = 'sim.start_step'
         ti = -1
-        ti_vals = []
-        for i,label in enumerate(self.plan.label):
-            if label == start_step:
+        for entry in self.plan:
+            if entry.label == start_step:
                 ti += 1
-            ti_vals.append(ti)
-        self.plan.loc[:, 'ti'] = ti_vals
+            entry.ti = ti
+
+        # Replay any user insertions tied to the current loop definition
+        for insertion in self.insertions:
+            self._insert_into_plan(**insertion)
 
         # Warn if any consecutive time values are close but not identical (likely a floating-point issue)
         eps = 1e-9
         try:
-            diffs = np.diff(np.float64(self.plan.time)) # May be date, so convert to float
+            diffs = np.diff(np.float64([entry.time for entry in self.plan])) # May be date, so convert to float
             small_diffs = diffs[(diffs > 0) & (diffs < eps)]
             if len(small_diffs):
                 warnmsg = f'{len(small_diffs)} integration loop entries have near-identical times, indicating a floating-point issue:\n{small_diffs}\nCheck your time units across the sim and modules!'
@@ -239,8 +256,8 @@ class Loop:
         Compare sim.run_one_step(), which runs a full timestep (which involves multiple function calls).
         """
         self._check_initialized()
-        f = self.plan.func[self.index] # Get the next function
-        f() # Call it
+        entry = self.plan[self.index] # Get the next entry
+        entry.func() # Call it
         self.index += 1 # Increment the time
         return
 
@@ -267,12 +284,12 @@ class Loop:
 
         # Loop over every function in the integration loop, e.g. disease.step()
         self.store_time()
-        for f,label in zip(self.plan.func[self.index:], self.plan.label[self.index:]):
+        while self.index < len(self.plan):
+            entry = self.plan[self.index]
             if verbose:
-                row = self.plan[self.index]
-                print(f'Running t={row.time:n}, step={row.name}, {label}()')
+                print(f'Running t={entry.time:n}, step={self.index}, {entry.label}()')
 
-            f() # Execute the function -- this is where all of Starsim happens!!
+            entry.func() # Execute the function -- this is where all of Starsim happens!!
 
             # Tidy up
             self.index += 1 # Increment the count
@@ -283,11 +300,50 @@ class Loop:
         self.to_df() # Store results as a dataframe
         return
 
+    def plan_metadata(self):
+        """ Return the dataframe view of the plan used for matching and display """
+        cols = ['time', 'ti', 'func_order', 'label', 'module', 'func_name']
+        rows = [{col:getattr(entry, col) for col in cols} for entry in self.plan]
+        return sc.dataframe(rows, columns=cols)
+
+    def _insert_into_plan(self, func, label=None, match_fn=None, before=False):
+        """ Insert into ``self.plan`` without recording the insertion for replay """
+        if label:
+            match_fn = lambda plan: plan.label == label
+
+        # Compute the matches against a dataframe metadata view
+        metadata = self.plan_metadata()
+        matches = match_fn(metadata)
+        matches = np.asarray(matches)
+        if matches.dtype == bool:
+            matches = sc.findinds(matches)
+
+        # Perform the insertion in reverse order
+        name = func.__name__
+        sim_func = lambda: func(self.sim) # Construct a partial function
+        for m in sorted(matches, reverse=True):
+            current = self.plan[m]
+            row = LoopEntry(
+                time = current.time,
+                ti = current.ti,
+                func_order = None,
+                func = sim_func,
+                label = name,
+                module = None,
+                func_name = name,
+            )
+            ind = m if before else m+1
+            self.plan.insert(ind, row)
+
+        self.df = None
+        self.cpu_df = None
+        return
+
     def insert(self, func, label=None, match_fn=None, before=False):
         """
         Insert a function into the loop plan at the specified location.
 
-        The loop plan is a dataframe with columns including time (e.g. `date('2025-05-05')`),
+        The loop plan metadata view is a dataframe with columns including time (e.g. `date('2025-05-05')`),
         label (e.g. `'randomnet.step'`), module ('`randomnet'`), and function name (`'step'`).
         By default, this method will match the conditions in the plan based on
         the criteria specified.
@@ -299,7 +355,7 @@ class Loop:
 
         Args:
             func (func): the function to insert; must take a single argument, `sim`
-            label (str): the label (module.name) of the function to match; see `sim.loop.plan.label.unique() for choices`
+            label (str): the label (module.name) of the function to match; see `sim.loop.to_df().label.unique() for choices`
             match_fn (func): if supplied, use this function to perform the matching on the plan dataframe, returning a boolean array or list of indices of matching rows (see example below)
             before (bool): if true, insert the function before rather than after the match
 
@@ -339,39 +395,16 @@ class Loop:
             errormsg = "You can supply label or match, but not both; 'label' is equivalent to 'plan.label == label', please include this in your match function"
             raise ValueError(errormsg)
 
-        if label:
-            match_fn = lambda plan: plan.label == label
-
-        # Compute the matches
-        matches = match_fn(self.plan)
-        if matches.dtype == bool:
-            matches = sc.findinds(matches)
-
-        # Perform the insertion in reverse order
-        name = func.__name__
-        sim_func = lambda: func(self.sim) # Construct a partial function
-        for m in matches[::-1]:
-            ind = m-1 if before else m
-            current = self.plan[ind]
-            row = dict(
-                time = current.time,
-                ti = current.ti,
-                func_order = None,
-                func = sim_func,
-                label = name,
-                module = None,
-                func_name = name,
-            )
-            self.plan.insertrow(ind, row)
-
+        insertion = dict(func=func, label=label, match_fn=match_fn, before=before)
+        self.insertions.append(insertion)
+        self._insert_into_plan(**insertion)
         return
 
     def to_df(self):
         """ Return a user-friendly version of the plan, omitting object columns """
         # Compute the main dataframe
-        cols = ['time', 'ti', 'func_order', 'label', 'module', 'func_name']
         if self.plan is not None:
-            df = self.plan[cols].copy() # Need to copy, otherwise it's messed up
+            df = self.plan_metadata()
         else:
             errormsg = f'Simulation "{self.sim}" needs to be initialized before exporting the Loop dataframe'
             raise RuntimeError(errormsg)
@@ -412,6 +445,8 @@ class Loop:
 
         # Assemble data
         df = self.df
+        if df is None:
+            df = self.to_df()
         if simplify:
             filter_out = ['update_results', 'finish_step']
             df = df[~df.func_name.isin(filter_out)]
@@ -519,6 +554,8 @@ class Loop:
         """
         self._check_initialized()
         df = self.df
+        if df is None:
+            df = self.to_df()
         if which == 'default':
             which = dict(func_name='step')
         if which:
@@ -562,17 +599,10 @@ class Loop:
         return ss.return_fig(fig)
 
     def __deepcopy__(self, memo):
-        """ A dataframe that has functions in it doesn't copy well; convert to a dict first """
+        """ Deep-copy the loop """
         cls = self.__class__
         new = cls.__new__(cls)
         memo[id(self)] = new
         for k, v in vars(self).items():
-            if k == 'plan' and isinstance(v, sc.dataframe):
-                origdict = v.to_dict() # Convert to a dictionary
-                newdict = sc.dcp(origdict, memo=memo, die=False) # Copy the dict
-                newdf = sc.dataframe(newdict)
-                setattr(new, k, newdf)
-            else:
-                setattr(new, k, sc.dcp(v, memo=memo, die=False)) # Regular deepcopy
+            setattr(new, k, sc.dcp(v, memo=memo, die=False))
         return new
-

--- a/starsim/sim.py
+++ b/starsim/sim.py
@@ -488,14 +488,14 @@ class Sim(ss.Base):
         self.loop.run(self.t.now(), verbose)
         return self
 
-    def run(self, until=None, verbose=None, shrink=True, check_method_calls=True):
+    def run(self, until=None, verbose=None, shrink=False, check_method_calls=True):
         """
         Run the model -- the main method for running a simulation.
 
         Args:
             until (date/str/float): the date to run the sim until
             verbose (float): the level of detail to print (default 0.1, i.e. output once every 10 steps)
-            shrink (bool): whether to shrink the sim after running to release memory
+            shrink (bool): whether to explicitly shrink the sim after running
             check_method_calls (bool): whether to check that all required methods were called
         """
         # Initialization steps
@@ -510,21 +510,24 @@ class Sim(ss.Base):
             errormsg = 'Simulation is already complete (call sim.init() to re-run)'
             raise AlreadyRunError(errormsg)
 
-        # Main simulation loop -- just one line!!!
-        self.loop.run(until)
+        try:
+            # Main simulation loop -- just one line!!!
+            self.loop.run(until)
 
-        # Check if the simulation is complete
-        if self.loop.index == len(self.loop.plan):
-            self.complete = True
+            # Check if the simulation is complete
+            if self.loop.index == len(self.loop.plan):
+                self.complete = True
 
-        # If simulation reached the end, finalize the results
-        if self.complete:
-            self.finalize()
-            if check_method_calls:
-                self.check_method_calls()
-            if shrink:
-                self.shrink(full=False)
-            sc.printv(f'Run finished after {self.elapsed:0.2f} s.\n', 1, self.verbose)
+            # If simulation reached the end, finalize the results
+            if self.complete:
+                self.finalize()
+                if check_method_calls:
+                    self.check_method_calls()
+                if shrink:
+                    self.shrink(full=False)
+                sc.printv(f'Run finished after {self.elapsed:0.2f} s.\n', 1, self.verbose)
+        finally:
+            self.dists.clear_run_caches()
         
         return self # Allows e.g. ss.Sim().run().plot()
 
@@ -1220,4 +1223,3 @@ def check_sims_match(*args, full=False):
         return matches
     else:
         return all(matches)
-

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -3,6 +3,9 @@ Test the Loop class
 """
 
 # %% Imports and settings
+import gc
+import weakref
+import pandas as pd
 import sciris as sc
 import starsim as ss
 
@@ -13,6 +16,14 @@ pars = sc.objdict(
     n_agents = 1000,
     diseases = 'sis',
     networks = 'random',
+)
+
+small_pars = sc.objdict(
+    dur = 5,
+    n_agents = 100,
+    diseases = 'sis',
+    networks = 'random',
+    rand_seed = 1,
 )
 
 
@@ -45,6 +56,129 @@ def test_loop_plotting():
     return sim.loop
 
 
+@sc.timer()
+def test_memory_cleanup():
+    """ Check split-run continuation and sim collectability without shrink(). """
+    sc.heading('Testing run memory cleanup...')
+
+    # Partial-run continuation should match an uninterrupted run
+    s1 = ss.Sim(small_pars).run()
+    s2 = ss.Sim(small_pars)
+    s2.run(until=1)
+    s2.run()
+    assert s1.summary == s2.summary, 'Split run does not match uninterrupted run'
+
+    # Partial and completed sims should be collectable without shrink()
+    sim = ss.Sim(small_pars)
+    sim.run(until=1)
+    ref = weakref.ref(sim)
+    del sim
+    gc.collect()
+    assert ref() is None, 'Partially run sim was not collectable'
+
+    sim = ss.Sim(small_pars).run()
+    ref = weakref.ref(sim)
+    del sim
+    gc.collect()
+    assert ref() is None, 'Completed sim was not collectable'
+
+    return
+
+
+@sc.timer()
+def test_callable_cache_cleanup():
+    """ Check callable distribution caches are cleared and safely regenerated. """
+    sc.heading('Testing callable distribution cache cleanup...')
+
+    def custom_duration(module, sim, uids):
+        return 5 + sim.people.age[uids] * 0
+
+    pars = sc.objdict(
+        dur = 5,
+        n_agents = 100,
+        diseases = ss.SIR(init_prev=0.2, dur_inf=ss.normal(loc=custom_duration, scale=0.1)),
+        networks = 'random',
+        rand_seed = 2,
+    )
+
+    # Clearing callable caches after a partial run should not change continuation results
+    s1 = ss.Sim(pars).run()
+    s2 = ss.Sim(pars)
+    s2.run(until=1)
+    for dist in s2.dists.dists.values():
+        assert getattr(dist, '_callable_args', None) is None
+        assert getattr(dist, '_callable_keys', None) is None
+    s2.run()
+    assert s1.summary == s2.summary, 'Callable cache regeneration changed results'
+
+    # The cleanup finally block should run even when the loop raises
+    sim = ss.Sim(pars).init()
+
+    def fail_after_cache(sim):
+        dist = next(iter(sim.dists.dists.values()))
+        dist._callable_args = {'sim': sim}
+        dist._callable_keys = ['sim']
+        raise RuntimeError('intentional loop failure')
+
+    sim.loop.insert(fail_after_cache, label='sim.start_step')
+    try:
+        sim.run()
+    except RuntimeError as err:
+        assert 'intentional loop failure' in str(err)
+    else:
+        raise AssertionError('Expected loop failure was not raised')
+
+    for dist in sim.dists.dists.values():
+        assert getattr(dist, '_callable_args', None) is None
+        assert getattr(dist, '_callable_keys', None) is None
+    del dist
+
+    ref = weakref.ref(sim)
+    del sim
+    gc.collect()
+    assert ref() is None, 'Exception-path sim was not collectable'
+
+    return
+
+
+@sc.timer()
+def test_loop_plan_views_and_insert():
+    """ Check Python loop storage, dataframe views, and insertion matching. """
+    sc.heading('Testing loop plan views and insertions...')
+
+    sim = ss.Sim(small_pars).init()
+    assert not isinstance(sim.loop.plan, pd.DataFrame)
+
+    df = sim.loop.to_df()
+    assert 'func' not in df.columns
+    assert sim.loop.df is df
+    assert sim.loop.cpu_df is not None
+
+    calls = []
+
+    def mark_label(sim):
+        calls.append(sim.ti)
+
+    sim.loop.insert(mark_label, label='sim.finish_step', before=True)
+    sim.run()
+    assert len(calls), 'Label-based insertion did not run'
+
+    calls = []
+    sim = ss.Sim(small_pars).init()
+
+    def mark_match(sim):
+        calls.append(sim.ti)
+
+    def match_fn(plan):
+        return plan.label == 'sim.finish_step'
+
+    sim.loop.insert(mark_match, match_fn=match_fn, before=True)
+    sim.run()
+    assert len(calls), 'Function-based insertion did not run'
+
+    return sim.loop
+
+
 # %% Run as a script
 if __name__ == '__main__':
     do_plot = True
@@ -54,5 +188,8 @@ if __name__ == '__main__':
     # Run tests
     l1 = test_run_options()
     l2 = test_loop_plotting()
+    l3 = test_memory_cleanup()
+    l4 = test_callable_cache_cleanup()
+    l5 = test_loop_plan_views_and_insert()
 
     T.toc()

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -361,7 +361,7 @@ def test_step_count():
             networks='random', n_agents=100, dur=ss.years(1), dt=sim_dt,
         )
         sim.init()
-        plan = sim.loop.plan
+        plan = sim.loop.to_df()
         disease_steps = plan[plan.label.str.contains('sis.step_state')]
         counts_per_ti = disease_steps.groupby('ti').size()
         max_calls = counts_per_ti.max()


### PR DESCRIPTION
### Description

Relating to the discussion in #1343 this proposes a more targeted clearing of content. For our memory leak case, there were two places causing problems

- `Dist._callable_args` containing references back to the `Sim` and `uids` etc.
- `sim.loop.plan` containing references to the `Sim` inside a dataframe, preventing garbage collection

Running `shrink(full=False)` is still potentially problematic in cases where the user has run with `sim.run(until=)` and also if an error is raised to terminate early. This PR proposes a fix in two parts

- `Dist._callable_args` is a temporary cache that will be automatically regenerated if it is cleared. Therefore, `sim.run()` can use a `finally` block to guarantee this cache is cleared when execution stops, and the `Sim` can just be directly resumed and the caches will be repopulated as required, no action required by the user
- `sim.loop.plan` is difficult to regenerate because the user may have called `.insert()` arbitrarily after initialization or during execution. However, it would not be necessary to clear the plan if the plan did not live within a dataframe. So this PR proposes one possible refactoring to have the plan be stored in pure Python containers so that garbage collection works without any complications, and then has a method to generate a dataframe representation of the plan on-demand

Together, these appear to resolve the memory leak while also correctly handling early termination, although it would be interesting if there are other scenarios where the leak persists. If proceeding with this, we could possibly remove the `full` argument from `shrink` so it would be clearer what the role of `shrink` is